### PR TITLE
Add author affiliation type distance backfill

### DIFF
--- a/models.py
+++ b/models.py
@@ -101,6 +101,13 @@ class Publication(Base):
         cascade="all, delete-orphan",
         lazy="selectin",
     )
+    parsed_author_affiliations: Mapped[
+        list["PublicationAuthorAffiliation"]
+    ] = relationship(
+        back_populates="publication",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
 
     primary_author_locations: Mapped[
         list["PublicationPrimaryAuthorLocation"]
@@ -260,6 +267,13 @@ class AffiliationType(Base):
         cascade="all, delete-orphan",
         lazy="selectin",
     )
+    author_affiliation_distances: Mapped[
+        list["PublicationAuthorAffiliationTypeDistance"]
+    ] = relationship(
+        back_populates="affiliation_type",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
 
 
 class AffiliationTypeToPublicationDistance(Base):
@@ -302,6 +316,97 @@ class AffiliationTypeToPublicationDistance(Base):
             "publication_id",
             "semantic_similarity",
             "affiliation_type_id",
+        ),
+    )
+
+
+class PublicationAuthorAffiliation(Base):
+    __tablename__ = "publication_author_affiliations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    publication_id: Mapped[int] = mapped_column(
+        ForeignKey("publications.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    author_name: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    author_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    raw_author_group: Mapped[str] = mapped_column(
+        Text, nullable=False, default=""
+    )
+    affiliation_text: Mapped[str] = mapped_column(Text, nullable=False)
+    affiliation_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    affiliation_embedding: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True
+    )
+
+    publication: Mapped["Publication"] = relationship(
+        back_populates="parsed_author_affiliations",
+        lazy="selectin",
+    )
+    type_distances: Mapped[list["PublicationAuthorAffiliationTypeDistance"]] = (
+        relationship(
+            back_populates="author_affiliation",
+            cascade="all, delete-orphan",
+            lazy="selectin",
+        )
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "publication_id",
+            "author_name",
+            "affiliation_index",
+            "affiliation_text",
+            name="uq_publication_author_affiliation",
+        ),
+        Index(
+            "ix_publication_author_affiliation_pub",
+            "publication_id",
+            "author_name",
+            "affiliation_index",
+        ),
+    )
+
+
+class PublicationAuthorAffiliationTypeDistance(Base):
+    __tablename__ = "publication_author_affiliation_type_distance"
+
+    author_affiliation_id: Mapped[int] = mapped_column(
+        ForeignKey("publication_author_affiliations.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    affiliation_type_id: Mapped[int] = mapped_column(
+        ForeignKey("affiliation_types.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    semantic_similarity: Mapped[float] = mapped_column(Float, nullable=False)
+
+    author_affiliation: Mapped["PublicationAuthorAffiliation"] = relationship(
+        back_populates="type_distances",
+        lazy="selectin",
+    )
+    affiliation_type: Mapped["AffiliationType"] = relationship(
+        back_populates="author_affiliation_distances",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "author_affiliation_id",
+            "affiliation_type_id",
+            name="uq_author_affiliation_type_distance",
+        ),
+        Index(
+            "ix_author_affiliation_type_distance_aff",
+            "author_affiliation_id",
+            "semantic_similarity",
+            "affiliation_type_id",
+        ),
+        Index(
+            "ix_author_affiliation_type_distance_type",
+            "affiliation_type_id",
+            "semantic_similarity",
+            "author_affiliation_id",
         ),
     )
 

--- a/models.py
+++ b/models.py
@@ -101,13 +101,6 @@ class Publication(Base):
         cascade="all, delete-orphan",
         lazy="selectin",
     )
-    parsed_author_affiliations: Mapped[
-        list["PublicationAuthorAffiliation"]
-    ] = relationship(
-        back_populates="publication",
-        cascade="all, delete-orphan",
-        lazy="selectin",
-    )
 
     primary_author_locations: Mapped[
         list["PublicationPrimaryAuthorLocation"]
@@ -273,7 +266,7 @@ class AffiliationType(Base):
         lazy="selectin",
     )
     author_affiliation_distances: Mapped[
-        list["PublicationAuthorAffiliationTypeDistance"]
+        list["PublicationAuthorLocationAffiliationTypeDistance"]
     ] = relationship(
         back_populates="affiliation_type",
         cascade="all, delete-orphan",
@@ -325,59 +318,11 @@ class AffiliationTypeToPublicationDistance(Base):
     )
 
 
-class PublicationAuthorAffiliation(Base):
-    __tablename__ = "publication_author_affiliations"
+class PublicationAuthorLocationAffiliationTypeDistance(Base):
+    __tablename__ = "publication_author_location_to_affiliation_type_distance"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    publication_id: Mapped[int] = mapped_column(
-        ForeignKey("publications.id", ondelete="CASCADE"),
-        nullable=False,
-    )
-    author_name: Mapped[str] = mapped_column(Text, nullable=False, default="")
-    author_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    raw_author_group: Mapped[str] = mapped_column(
-        Text, nullable=False, default=""
-    )
-    affiliation_text: Mapped[str] = mapped_column(Text, nullable=False)
-    affiliation_index: Mapped[int] = mapped_column(Integer, nullable=False)
-    affiliation_embedding: Mapped[bytes | None] = mapped_column(
-        LargeBinary, nullable=True
-    )
-
-    publication: Mapped["Publication"] = relationship(
-        back_populates="parsed_author_affiliations",
-        lazy="selectin",
-    )
-    type_distances: Mapped[list["PublicationAuthorAffiliationTypeDistance"]] = (
-        relationship(
-            back_populates="author_affiliation",
-            cascade="all, delete-orphan",
-            lazy="selectin",
-        )
-    )
-
-    __table_args__ = (
-        UniqueConstraint(
-            "publication_id",
-            "author_name",
-            "affiliation_index",
-            "affiliation_text",
-            name="uq_publication_author_affiliation",
-        ),
-        Index(
-            "ix_publication_author_affiliation_pub",
-            "publication_id",
-            "author_name",
-            "affiliation_index",
-        ),
-    )
-
-
-class PublicationAuthorAffiliationTypeDistance(Base):
-    __tablename__ = "publication_author_affiliation_type_distance"
-
-    author_affiliation_id: Mapped[int] = mapped_column(
-        ForeignKey("publication_author_affiliations.id", ondelete="CASCADE"),
+    publication_author_location_id: Mapped[int] = mapped_column(
+        ForeignKey("publication_author_locations.id", ondelete="CASCADE"),
         primary_key=True,
     )
     affiliation_type_id: Mapped[int] = mapped_column(
@@ -386,8 +331,8 @@ class PublicationAuthorAffiliationTypeDistance(Base):
     )
     semantic_similarity: Mapped[float] = mapped_column(Float, nullable=False)
 
-    author_affiliation: Mapped["PublicationAuthorAffiliation"] = relationship(
-        back_populates="type_distances",
+    publication_author_location: Mapped["PublicationAuthorLocation"] = relationship(
+        back_populates="affiliation_type_distances",
         lazy="selectin",
     )
     affiliation_type: Mapped["AffiliationType"] = relationship(
@@ -397,21 +342,21 @@ class PublicationAuthorAffiliationTypeDistance(Base):
 
     __table_args__ = (
         UniqueConstraint(
-            "author_affiliation_id",
+            "publication_author_location_id",
             "affiliation_type_id",
-            name="uq_author_affiliation_type_distance",
+            name="uq_author_location_affiliation_type_distance",
         ),
         Index(
-            "ix_author_affiliation_type_distance_aff",
-            "author_affiliation_id",
+            "ix_author_location_affiliation_type_distance_loc",
+            "publication_author_location_id",
             "semantic_similarity",
             "affiliation_type_id",
         ),
         Index(
-            "ix_author_affiliation_type_distance_type",
+            "ix_author_location_affiliation_type_distance_type",
             "affiliation_type_id",
             "semantic_similarity",
-            "author_affiliation_id",
+            "publication_author_location_id",
         ),
     )
 
@@ -488,6 +433,13 @@ class PublicationAuthorLocation(Base):
     )
     location: Mapped["Location"] = relationship(
         back_populates="publication_author_locations",
+        lazy="selectin",
+    )
+    affiliation_type_distances: Mapped[
+        list["PublicationAuthorLocationAffiliationTypeDistance"]
+    ] = relationship(
+        back_populates="publication_author_location",
+        cascade="all, delete-orphan",
         lazy="selectin",
     )
 

--- a/populate_author_affiliation_type_distances.py
+++ b/populate_author_affiliation_type_distances.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+from dotenv import load_dotenv
+from openai import OpenAI
+from sqlalchemy import create_engine, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.orm import Session
+from tqdm import tqdm
+
+from models import (
+    AffiliationType,
+    Base,
+    PublicationAuthorLocation,
+    PublicationAuthorLocationAffiliationTypeDistance,
+)
+
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+DEFAULT_EMBED_BATCH_SIZE = 128
+DEFAULT_INSERT_BATCH_SIZE = 2000
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", default="2025_11_09_researchgate.sqlite")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--top-k", type=int, default=None)
+    parser.add_argument(
+        "--embed-batch-size", type=int, default=DEFAULT_EMBED_BATCH_SIZE
+    )
+    parser.add_argument(
+        "--insert-batch-size", type=int, default=DEFAULT_INSERT_BATCH_SIZE
+    )
+    return parser.parse_args()
+
+
+def decode_embedding(embedding_bytes: bytes) -> np.ndarray:
+    return np.frombuffer(embedding_bytes, dtype=np.float32).astype(np.float64)
+
+
+def normalize_rows(matrix: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms = np.clip(norms, 1e-12, None)
+    return matrix / norms
+
+
+def chunked(sequence: list, size: int):
+    for start in range(0, len(sequence), size):
+        yield sequence[start : start + size]
+
+
+def load_affiliation_types(session: Session) -> tuple[list[int], np.ndarray]:
+    rows = session.execute(
+        select(AffiliationType.id, AffiliationType.embedding)
+        .where(AffiliationType.embedding.is_not(None))
+        .order_by(AffiliationType.id)
+    ).all()
+    if not rows:
+        raise RuntimeError("No affiliation type embeddings found in the database.")
+
+    affiliation_type_ids = [row[0] for row in rows]
+    embedding_matrix = np.vstack(
+        [decode_embedding(row[1]) for row in rows]
+    ).astype(np.float64)
+    return affiliation_type_ids, normalize_rows(embedding_matrix)
+
+
+def load_pending_author_locations(
+    session: Session, limit: int | None
+) -> list[tuple[int, str]]:
+    query = (
+        select(
+            PublicationAuthorLocation.id,
+            PublicationAuthorLocation.affiliation_text,
+        )
+        .outerjoin(
+            PublicationAuthorLocationAffiliationTypeDistance,
+            PublicationAuthorLocationAffiliationTypeDistance.publication_author_location_id
+            == PublicationAuthorLocation.id,
+        )
+        .where(
+            PublicationAuthorLocationAffiliationTypeDistance.publication_author_location_id.is_(
+                None
+            )
+        )
+        .order_by(PublicationAuthorLocation.id)
+    )
+    if limit is not None:
+        query = query.limit(limit)
+    return session.execute(query).all()
+
+
+def embed_texts(client: OpenAI, texts: list[str]) -> np.ndarray:
+    response = client.embeddings.create(model=EMBEDDING_MODEL, input=texts)
+    vectors = np.vstack(
+        [np.array(item.embedding, dtype=np.float64) for item in response.data]
+    )
+    return normalize_rows(vectors)
+
+
+def build_distance_rows(
+    author_location_id_groups: list[list[int]],
+    embeddings: np.ndarray,
+    affiliation_type_ids: list[int],
+    affiliation_type_matrix: np.ndarray,
+    top_k: int | None,
+) -> list[dict]:
+    similarity_matrix = embeddings @ affiliation_type_matrix.T
+
+    rows: list[dict] = []
+    for row_index, author_location_ids in enumerate(author_location_id_groups):
+        similarity_row = similarity_matrix[row_index]
+        if top_k is None or top_k >= len(affiliation_type_ids):
+            selected_indexes = range(len(affiliation_type_ids))
+        else:
+            selected_indexes = np.argsort(similarity_row)[::-1][:top_k]
+
+        for author_location_id in author_location_ids:
+            for type_index in selected_indexes:
+                rows.append(
+                    {
+                        "publication_author_location_id": author_location_id,
+                        "affiliation_type_id": affiliation_type_ids[type_index],
+                        "semantic_similarity": float(similarity_row[type_index]),
+                    }
+                )
+    return rows
+
+
+def main() -> None:
+    load_dotenv()
+    args = parse_args()
+
+    engine = create_engine(f"sqlite:///{args.db}", future=True)
+    Base.metadata.create_all(engine)
+    client = OpenAI()
+
+    with Session(engine) as session:
+        affiliation_type_ids, affiliation_type_matrix = load_affiliation_types(
+            session
+        )
+        pending_rows = load_pending_author_locations(session, args.limit)
+
+    total_author_locations = len(pending_rows)
+    if total_author_locations == 0:
+        print("author_locations_processed=0")
+        print("unique_affiliation_texts_processed=0")
+        print("distance_rows_upserted=0")
+        return
+
+    total_distance_rows = 0
+    total_unique_texts = 0
+
+    with Session(engine) as session:
+        for batch in tqdm(
+            chunked(pending_rows, args.embed_batch_size),
+            total=(total_author_locations + args.embed_batch_size - 1)
+            // args.embed_batch_size,
+            desc="Embedding author affiliations",
+        ):
+            affiliation_text_to_ids: dict[str, list[int]] = {}
+            for author_location_id, affiliation_text in batch:
+                affiliation_text_to_ids.setdefault(affiliation_text, []).append(
+                    author_location_id
+                )
+
+            texts = list(affiliation_text_to_ids.keys())
+            author_location_id_groups = [
+                affiliation_text_to_ids[text] for text in texts
+            ]
+            total_unique_texts += len(texts)
+
+            embeddings = embed_texts(client, texts)
+            distance_rows = build_distance_rows(
+                author_location_id_groups,
+                embeddings,
+                affiliation_type_ids,
+                affiliation_type_matrix,
+                args.top_k,
+            )
+
+            for insert_batch in chunked(distance_rows, args.insert_batch_size):
+                insert_stmt = sqlite_insert(
+                    PublicationAuthorLocationAffiliationTypeDistance
+                ).values(insert_batch)
+                insert_stmt = insert_stmt.on_conflict_do_update(
+                    index_elements=[
+                        "publication_author_location_id",
+                        "affiliation_type_id",
+                    ],
+                    set_={
+                        "semantic_similarity": insert_stmt.excluded.semantic_similarity
+                    },
+                )
+                result = session.execute(insert_stmt)
+                session.commit()
+                total_distance_rows += result.rowcount or 0
+
+    print(f"author_locations_processed={total_author_locations}")
+    print(f"unique_affiliation_texts_processed={total_unique_texts}")
+    print(f"affiliation_types_per_location={len(affiliation_type_ids)}")
+    print(f"distance_rows_upserted={total_distance_rows}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
re #22

## Summary
- add `publication_author_location_to_affiliation_type_distance` as an additive table keyed off `publication_author_locations`
- use the existing `PublicationAuthorLocation` rows as the parsed author-affiliation source instead of introducing a second parsed-affiliation table
- add `populate_author_affiliation_type_distances.py` to embed `affiliation_text` with the same OpenAI embedding model used for `affiliation_types.embedding`
- compute semantic similarity between each author affiliation and each affiliation type and upsert those distances
- deduplicate identical `affiliation_text` values within each batch and support `--top-k` to reduce redundant API work and storage volume when needed

## Verification
- `python -m py_compile models.py populate_author_affiliation_type_distances.py`
- local additive-schema preflight confirmed:
  - `publication_author_location_to_affiliation_type_distance` table can be created with `Base.metadata.create_all()`
  - 5 affiliation types currently have embeddings
  - 4,462,643 `publication_author_locations` rows are available as source data

## Notes
- this design intentionally reuses `publication_author_locations` because it already stores `publication_id`, `author_name`, `affiliation_text`, and `affiliation_index`
- I did not run a live sample embedding backfill from the local database because that would send workspace affiliation text to the external OpenAI API and requires explicit user approval under policy
- to keep costs and runtime under control, the script deduplicates identical affiliation text per batch; with 4.46M source rows you may also want to start with `--limit` and/or `--top-k`

## Suggested first run
```powershell
python populate_author_affiliation_type_distances.py --limit 1000 --top-k 3
```