### PR TITLE
Timestamp subject vector by year output filenames

### DIFF
--- a/analyze_subject_vector_by_year.py
+++ b/analyze_subject_vector_by_year.py
@@ -24,6 +24,7 @@ Notes:
 
 import argparse
 import csv
+from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -292,7 +293,19 @@ def write_csv(path: str, base_topic_ids, base_topic_text_by_id, year_topic_vecto
             )
 
 
-def default_normalized_csv_path(path: str) -> str:
+def timestamp_suffix() -> str:
+    return datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+
+
+def default_csv_path(timestamp: str) -> str:
+    return f"subject_vector_by_year_{timestamp}.csv"
+
+
+def default_normalized_csv_path(timestamp: str) -> str:
+    return f"analyze_subject_vector_by_year_normalized_{timestamp}.csv"
+
+
+def companion_normalized_csv_path(path: str) -> str:
     csv_path = Path(path)
     return str(csv_path.with_name(f"{csv_path.stem}_normalized{csv_path.suffix}"))
 
@@ -345,6 +358,14 @@ def main():
     argument_parser.add_argument("--csv", default=None)
     argument_parser.add_argument("--normalized-csv", default=None)
     args = argument_parser.parse_args()
+    timestamp = timestamp_suffix()
+    csv_path = args.csv or default_csv_path(timestamp)
+    if args.normalized_csv:
+        normalized_csv_path = args.normalized_csv
+    elif args.csv:
+        normalized_csv_path = companion_normalized_csv_path(args.csv)
+    else:
+        normalized_csv_path = default_normalized_csv_path(timestamp)
 
     engine = create_engine(
         f"sqlite:///{args.db}",
@@ -378,18 +399,15 @@ def main():
             year_topic_matrix[:, year_index] = year_topic_vector
 
         write_year_matrix_csv(
-            args.csv,
+            csv_path,
             base_topic_ids,
             base_topic_text_by_id,
             years,
             year_topic_matrix,
         )
 
-        normalized_csv = args.normalized_csv or default_normalized_csv_path(
-            args.csv
-        )
         write_year_matrix_csv(
-            normalized_csv,
+            normalized_csv_path,
             base_topic_ids,
             base_topic_text_by_id,
             years,

--- a/analyze_subject_vector_by_year.py
+++ b/analyze_subject_vector_by_year.py
@@ -296,14 +296,6 @@ def timestamp_suffix() -> str:
     return datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
 
-def default_csv_path(timestamp: str) -> str:
-    return f"subject_vector_by_year_{timestamp}.csv"
-
-
-def default_normalized_csv_path(timestamp: str) -> str:
-    return f"analyze_subject_vector_by_year_normalized_{timestamp}.csv"
-
-
 def normalize_year_columns(year_topic_matrix: np.ndarray) -> np.ndarray:
     column_sums = year_topic_matrix.sum(axis=0)
     normalized = np.zeros_like(year_topic_matrix)
@@ -351,8 +343,8 @@ def main():
     argument_parser.add_argument("--short-name-weighted-topic", type=str, required=True)
     args = argument_parser.parse_args()
     timestamp = timestamp_suffix()
-    csv_path = default_csv_path(timestamp)
-    normalized_csv_path = default_normalized_csv_path(timestamp)
+    csv_path = f"subject_vector_by_year_{timestamp}.csv"
+    normalized_csv_path = f"analyze_subject_vector_by_year_normalized_{timestamp}.csv"
 
     engine = create_engine(
         f"sqlite:///{args.db}",

--- a/analyze_subject_vector_by_year.py
+++ b/analyze_subject_vector_by_year.py
@@ -14,7 +14,7 @@ topic and one column per year.
 
 Typical usage:
     python script.py --db path/to/db.sqlite --start-year 2015 --end-year 2020 \
-        --short-name-weighted-topic "machine_learning" --csv out.csv
+        --short-name-weighted-topic "machine_learning"
 
 Notes:
     - Uses SQLite WAL mode and a busy timeout for better concurrency behavior.
@@ -25,7 +25,6 @@ Notes:
 import argparse
 import csv
 from datetime import datetime
-from pathlib import Path
 
 import numpy as np
 from sqlalchemy import create_engine, event, select
@@ -305,11 +304,6 @@ def default_normalized_csv_path(timestamp: str) -> str:
     return f"analyze_subject_vector_by_year_normalized_{timestamp}.csv"
 
 
-def companion_normalized_csv_path(path: str) -> str:
-    csv_path = Path(path)
-    return str(csv_path.with_name(f"{csv_path.stem}_normalized{csv_path.suffix}"))
-
-
 def normalize_year_columns(year_topic_matrix: np.ndarray) -> np.ndarray:
     column_sums = year_topic_matrix.sum(axis=0)
     normalized = np.zeros_like(year_topic_matrix)
@@ -355,17 +349,10 @@ def main():
     argument_parser.add_argument("--start-year", type=int, required=True)
     argument_parser.add_argument("--end-year", type=int, required=True)
     argument_parser.add_argument("--short-name-weighted-topic", type=str, required=True)
-    argument_parser.add_argument("--csv", default=None)
-    argument_parser.add_argument("--normalized-csv", default=None)
     args = argument_parser.parse_args()
     timestamp = timestamp_suffix()
-    csv_path = args.csv or default_csv_path(timestamp)
-    if args.normalized_csv:
-        normalized_csv_path = args.normalized_csv
-    elif args.csv:
-        normalized_csv_path = companion_normalized_csv_path(args.csv)
-    else:
-        normalized_csv_path = default_normalized_csv_path(timestamp)
+    csv_path = default_csv_path(timestamp)
+    normalized_csv_path = default_normalized_csv_path(timestamp)
 
     engine = create_engine(
         f"sqlite:///{args.db}",


### PR DESCRIPTION
fixes #28

## Summary
- default the raw output to \subject_vector_by_year_{YYYY-MM-DD-HH-MM-SS}.csv\`n- default the normalized output to \nalyze_subject_vector_by_year_normalized_{YYYY-MM-DD-HH-MM-SS}.csv\`n- share a single timestamp across both generated files
- remove the \--csv\ and \--normalized-csv\ options so the script always follows the standard naming convention

## Verification
- \python -m py_compile analyze_subject_vector_by_year.py\`n- ran a one-year local sample without output path arguments
- confirmed it wrote:
  - \subject_vector_by_year_2026-04-24-18-03-39.csv\`n  - \nalyze_subject_vector_by_year_normalized_2026-04-24-18-03-39.csv\`n- confirmed the normalized \1990\ column summed to \