### PR TITLE
Normalize subject vectors by year without topic weighting

### DIFF
--- a/analyze_subject_vector_by_year.py
+++ b/analyze_subject_vector_by_year.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 Compute per-year base-topic distributions for publications stored in a SQLite database.
 
 This script queries a ResearchGate-derived SQLite database containing publications, base topics,
-and per-publication distances (semantic similarities) to base topics. For each publication in a
-given year, it computes a temperature-scaled softmax distribution over that publication's base
-topics (optionally reweighted by the publication's similarity to a chosen base topic), then
-sums those distributions across all publications in the year to form a year-level topic vector.
+and per-publication distances (semantic similarities) to base topics. For each year, it sums
+the semantic similarity scores for each base topic across all publications in that year to form
+a year-level topic vector. It also writes a normalized companion matrix where each year column
+sums to 1.0.
 
 The script can compute vectors across a year range and write a CSV matrix with one row per base
 topic and one column per year.
 
 Typical usage:
-    python script.py --db path/to/db.sqlite --start-year 2015 --end-year 2020 \
-        --short-name-weighted-topic "machine_learning"
+    python script.py --db path/to/db.sqlite --start-year 2015 --end-year 2020
 
 Notes:
     - Uses SQLite WAL mode and a busy timeout for better concurrency behavior.
@@ -27,7 +26,7 @@ import csv
 from datetime import datetime
 
 import numpy as np
-from sqlalchemy import create_engine, event, select
+from sqlalchemy import create_engine, event, func, select
 from sqlalchemy.orm import Session
 
 from models import BaseTopics, BaseTopicToPublicationDistance, Publication
@@ -90,150 +89,53 @@ def _load_base_topics(session: Session):
 def year_vector(
     session: Session,
     year: int,
-    weighted_short_name: str,
+    base_topic_ids_all,
+    base_topic_index_by_id: dict[int, int],
 ):
-    """Compute a year-level base-topic vector by aggregating publication-level softmax weights.
+    """Compute a year-level base-topic vector by summing topic scores.
 
-    For each publication in the specified year, this function:
-      1) collects (base_topic_id, semantic_similarity) pairs
-      2) finds the publication's similarity for `weighted_short_name` (if present) and uses it
-         as a multiplicative factor on all topic scores for that publication
-      3) applies temperature-scaled softmax to the per-publication scores
-      4) accumulates the resulting weights into a year-level vector over base topics
+    For each publication in the specified year, this function adds each base topic's
+    semantic similarity score to the corresponding year-level topic total.
 
     Args:
         session: An active SQLAlchemy session.
         year: Publication year to aggregate.
-        weighted_short_name: Base topic short name whose semantic similarity (per publication)
-            is used as a multiplicative weight for that publication's scores.
+        base_topic_ids_all: NumPy array of all base topic IDs (int64), ordered by ID.
+        base_topic_index_by_id: Dict mapping base topic ID (int) -> index (int).
 
     Returns:
-        tuple:
-            base_topic_ids_all: NumPy array of all base topic IDs (int64), ordered by ID.
-            base_topic_text_by_id: Dict mapping base topic ID (int) -> short name (str).
-            year_topic_vector: NumPy array (float64) with summed softmax weights per base topic.
+        NumPy array (float64) with summed semantic similarity per base topic.
     """
-    print(f"[year_vector] start year={year} weighted_short_name={weighted_short_name}")
-
-    (
-        base_topic_ids_all,
-        base_topic_text_by_id,
-        base_topic_index_by_id,
-    ) = _load_base_topics(session)
-
-    print(f"[year_vector] loaded {len(base_topic_ids_all)} base topics")
+    print(f"[year_vector] start year={year}")
 
     year_topic_vector = np.zeros(len(base_topic_ids_all), dtype=np.float64)
 
-    weighted_base_topic_id = session.execute(
-        select(BaseTopics.id).where(BaseTopics.short_name == weighted_short_name)
-    ).scalar_one()
-
-    print(f"[year_vector] weighted_base_topic_id={weighted_base_topic_id}")
-
     query = (
         select(
-            BaseTopicToPublicationDistance.publication_id,
             BaseTopicToPublicationDistance.base_topic_id,
-            BaseTopicToPublicationDistance.semantic_similarity,
+            func.sum(BaseTopicToPublicationDistance.semantic_similarity),
         )
         .join(
             Publication,
             Publication.id == BaseTopicToPublicationDistance.publication_id,
         )
         .where(Publication.publication_year == year)
-    )
-
-    query = query.order_by(
-        BaseTopicToPublicationDistance.publication_id,
-        BaseTopicToPublicationDistance.base_topic_id,
+        .group_by(BaseTopicToPublicationDistance.base_topic_id)
+        .order_by(BaseTopicToPublicationDistance.base_topic_id)
     )
 
     print("[year_vector] executing main query")
 
-    rows = session.execute(query)
-
-    temperature = 0.3
-
-    current_publication_id = None
-    publication_base_topic_ids: list[int] = []
-    publication_scores: list[float] = []
-
-    publication_counter = 0
     row_counter = 0
-
-    def flush():
-        """Flush accumulated rows for the current publication into the year vector.
-
-        Computes the per-publication softmax distribution over base topics (after optional
-        weighting and temperature scaling) and adds it to `year_topic_vector`.
-
-        Returns:
-            None
-        """
-        nonlocal publication_counter
-
-        if not publication_scores:
-            return
-
-        publication_counter += 1
-
-        if publication_counter % 10000 == 0:
-            print(
-                f"[year_vector] flushed {publication_counter} publications "
-                f"(rows processed={row_counter})"
-            )
-
-        weighted_score = 1.0
-        for base_topic_id, semantic_similarity in zip(
-            publication_base_topic_ids, publication_scores, strict=True
-        ):
-            if base_topic_id == weighted_base_topic_id:
-                weighted_score = float(semantic_similarity)
-                break
-
-        scores = np.array(publication_scores, dtype=np.float64)
-        scores = np.maximum(scores, 0.0)
-        scores = scores * weighted_score
-        scores = scores / temperature
-
-        max_score = float(scores.max())
-        exponentials = np.exp(scores - max_score)
-        denominator = float(exponentials.sum())
-        if denominator == 0.0:
-            return
-        exponentials = exponentials / denominator
-        for base_topic_id, weight in zip(
-            publication_base_topic_ids, exponentials, strict=True
-        ):
-            year_topic_vector[base_topic_index_by_id[base_topic_id]] += float(weight)
-
-    for publication_id, base_topic_id, semantic_similarity in rows:
+    for base_topic_id, semantic_similarity_sum in session.execute(query):
         row_counter += 1
+        year_topic_vector[base_topic_index_by_id[base_topic_id]] = float(
+            semantic_similarity_sum or 0.0
+        )
 
-        if row_counter % 100000 == 0:
-            print(f"[year_vector] processed {row_counter} rows")
+    print(f"[year_vector] done year={year} total_topics={row_counter}")
 
-        if current_publication_id is None:
-            current_publication_id = publication_id
-
-        if publication_id != current_publication_id:
-            flush()
-            current_publication_id = publication_id
-            publication_base_topic_ids = []
-            publication_scores = []
-
-        publication_base_topic_ids.append(base_topic_id)
-        publication_scores.append(semantic_similarity)
-
-    flush()
-
-    print(
-        f"[year_vector] done year={year} "
-        f"total_rows={row_counter} total_publications={publication_counter}"
-    )
-
-    return base_topic_ids_all, base_topic_text_by_id, year_topic_vector
+    return year_topic_vector
 
 
 def topk(base_topic_ids, base_topic_text_by_id, year_topic_vector, k: int):
@@ -340,7 +242,6 @@ def main():
     argument_parser.add_argument("--db", default=DB_PATH)
     argument_parser.add_argument("--start-year", type=int, required=True)
     argument_parser.add_argument("--end-year", type=int, required=True)
-    argument_parser.add_argument("--short-name-weighted-topic", type=str, required=True)
     args = argument_parser.parse_args()
     timestamp = timestamp_suffix()
     csv_path = f"subject_vector_by_year_{timestamp}.csv"
@@ -355,10 +256,8 @@ def main():
     with Session(engine) as session:
         years = list(range(args.start_year, args.end_year + 1))
 
-        base_topic_ids, base_topic_text_by_id, _ = year_vector(
-            session,
-            year=years[0],
-            weighted_short_name=args.short_name_weighted_topic,
+        base_topic_ids, base_topic_text_by_id, base_topic_index_by_id = (
+            _load_base_topics(session)
         )
 
         year_topic_matrix = np.zeros(
@@ -366,14 +265,11 @@ def main():
         )
 
         for year_index, year_value in enumerate(years):
-            (
-                base_topic_ids_for_year,
-                base_topic_text_by_id_for_year,
-                year_topic_vector,
-            ) = year_vector(
+            year_topic_vector = year_vector(
                 session,
                 year=year_value,
-                weighted_short_name=args.short_name_weighted_topic,
+                base_topic_ids_all=base_topic_ids,
+                base_topic_index_by_id=base_topic_index_by_id,
             )
             year_topic_matrix[:, year_index] = year_topic_vector
 


### PR DESCRIPTION
## Summary
- Removes the required `--short-name-weighted-topic` argument from `analyze_subject_vector_by_year.py`
- Replaces the per-publication weighted softmax path with direct yearly sums of `semantic_similarity` grouped by base topic
- Keeps the raw timestamped subject vector output and normalized companion output, where each year column sums to `1.0`

## Validation
- `python -m py_compile analyze_subject_vector_by_year.py`

## Notes
- Full runtime smoke test was blocked locally because the active Python at `C:\Python313\python.exe` is missing `numpy` and `sqlalchemy`.

Fixes #30