### PR TITLE
Normalize affiliation year outputs with positive weights

### DIFF
--- a/analyze_affiliation_country_subject_year.py
+++ b/analyze_affiliation_country_subject_year.py
@@ -1,12 +1,25 @@
 from datetime import datetime
+import logging
 from pathlib import Path
+from time import perf_counter
 
 import pandas as pd
 from sqlalchemy import create_engine, text
 
+try:
+    from tqdm import tqdm
+except ImportError:
+    tqdm = None
+
 db_path = "2025_11_09_researchgate.sqlite"
 out_dir = Path("topic_mapping_reports")
 timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 out_dir.mkdir(exist_ok=True)
 
@@ -136,11 +149,37 @@ def normalize_year_columns(pivot: pd.DataFrame) -> pd.DataFrame:
     return normalized
 
 
+def elapsed_seconds(start_time: float) -> str:
+    return f"{perf_counter() - start_time:.1f}s"
+
+
 engine = create_engine(f"sqlite:///{db_path}")
 
+logger.info("Starting affiliation country/subject/year analysis")
+logger.info("Database: %s", db_path)
+logger.info("Output directory: %s", out_dir)
+logger.info("Timestamp suffix: %s", timestamp)
+
+report_iterator = reports
+if tqdm is not None:
+    report_iterator = tqdm(reports, desc="reports", unit="report")
+
 with engine.connect() as conn:
-    for stem, row_name, col_name, title, query in reports:
+    for stem, row_name, col_name, title, query in report_iterator:
+        report_start = perf_counter()
+        logger.info("Starting report: %s", stem)
+        logger.info("Running SQL query for %s", stem)
+        query_start = perf_counter()
         df = pd.read_sql_query(text(query), conn)
+        logger.info(
+            "SQL complete for %s: rows=%s elapsed=%s",
+            stem,
+            len(df),
+            elapsed_seconds(query_start),
+        )
+
+        logger.info("Building pivot for %s", stem)
+        pivot_start = perf_counter()
         pivot = (
             df.pivot(index="row_label", columns="column_label", values="count")
             .fillna(0)
@@ -150,9 +189,25 @@ with engine.connect() as conn:
         pivot = pivot.reindex(sorted(pivot.columns.tolist()), axis=1)
         pivot.index.name = row_name
         pivot.columns.name = col_name
+        logger.info(
+            "Pivot complete for %s: rows=%s columns=%s elapsed=%s",
+            stem,
+            pivot.shape[0],
+            pivot.shape[1],
+            elapsed_seconds(pivot_start),
+        )
 
         csv_path = out_dir / f"{stem}_{timestamp}.csv"
+        logger.info("Writing CSV for %s: %s", stem, csv_path)
         pivot.to_csv(csv_path)
         if col_name == "Year":
             normalized_csv_path = out_dir / f"{stem}_normalized_{timestamp}.csv"
+            logger.info(
+                "Writing normalized year CSV for %s: %s",
+                stem,
+                normalized_csv_path,
+            )
             normalize_year_columns(pivot).to_csv(normalized_csv_path)
+        logger.info("Finished report: %s elapsed=%s", stem, elapsed_seconds(report_start))
+
+logger.info("Finished affiliation country/subject/year analysis")

--- a/analyze_affiliation_country_subject_year.py
+++ b/analyze_affiliation_country_subject_year.py
@@ -10,7 +10,7 @@ from sqlalchemy import create_engine, text
 
 db_path = "2025_11_09_researchgate.sqlite"
 out_dir = Path("topic_mapping_reports")
-timestamp = datetime.now().strftime("%Y_%m_%d_%M_%S")
+timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
 out_dir.mkdir(exist_ok=True)
 
@@ -27,6 +27,7 @@ with top_subject as (
             ) as rn
         from base_topic_to_pub_distance btpd
         join base_topics bt on bt.id = btpd.base_topic_id
+        where btpd.semantic_similarity > 0
     )
     where rn = 1
 ),
@@ -42,6 +43,7 @@ top_affiliation as (
             ) as rn
         from affiliation_type_to_pub_distance atpd
         join affiliation_types aft on aft.id = atpd.affiliation_type_id
+        where atpd.semantic_similarity > 0
     )
     where rn = 1
 ),
@@ -126,6 +128,18 @@ reports = [
     ),
 ]
 
+
+def normalize_year_columns(pivot: pd.DataFrame) -> pd.DataFrame:
+    column_sums = pivot.sum(axis=0)
+    normalized = pivot.astype(float).copy()
+    nonzero_columns = column_sums != 0
+    normalized.loc[:, nonzero_columns] = (
+        normalized.loc[:, nonzero_columns] / column_sums[nonzero_columns]
+    )
+    normalized.loc[:, ~nonzero_columns] = 0.0
+    return normalized
+
+
 engine = create_engine(f"sqlite:///{db_path}")
 
 with engine.connect() as conn:
@@ -145,6 +159,9 @@ with engine.connect() as conn:
         png_path = out_dir / f"{stem}_{timestamp}.png"
 
         pivot.to_csv(csv_path)
+        if col_name == "Year":
+            normalized_csv_path = out_dir / f"{stem}_normalized_{timestamp}.csv"
+            normalize_year_columns(pivot).to_csv(normalized_csv_path)
 
         fig, ax = plt.subplots(
             figsize=(

--- a/analyze_affiliation_country_subject_year.py
+++ b/analyze_affiliation_country_subject_year.py
@@ -1,10 +1,6 @@
 from datetime import datetime
 from pathlib import Path
 
-import matplotlib
-
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 import pandas as pd
 from sqlalchemy import create_engine, text
 
@@ -156,28 +152,7 @@ with engine.connect() as conn:
         pivot.columns.name = col_name
 
         csv_path = out_dir / f"{stem}_{timestamp}.csv"
-        png_path = out_dir / f"{stem}_{timestamp}.png"
-
         pivot.to_csv(csv_path)
         if col_name == "Year":
             normalized_csv_path = out_dir / f"{stem}_normalized_{timestamp}.csv"
             normalize_year_columns(pivot).to_csv(normalized_csv_path)
-
-        fig, ax = plt.subplots(
-            figsize=(
-                max(8, pivot.shape[1] * 0.6),
-                max(6, pivot.shape[0] * 0.35),
-            )
-        )
-        image = ax.imshow(pivot.to_numpy(), aspect="auto")
-        ax.set_title(title)
-        ax.set_xlabel(col_name)
-        ax.set_ylabel(row_name)
-        ax.set_xticks(range(pivot.shape[1]))
-        ax.set_xticklabels([str(x) for x in pivot.columns], rotation=90)
-        ax.set_yticks(range(pivot.shape[0]))
-        ax.set_yticklabels([str(x) for x in pivot.index])
-        fig.colorbar(image, ax=ax, label="Publication count")
-        fig.tight_layout()
-        fig.savefig(png_path, dpi=200, bbox_inches="tight")
-        plt.close(fig)

--- a/analyze_affiliation_vector_by_year.py
+++ b/analyze_affiliation_vector_by_year.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 Compute per-year affiliation-type distributions for publications in a SQLite database.
 
 This script aggregates semantic similarity scores between publications and
-affiliation types into yearly distributions. For each publication in a given
-year, it computes a temperature-scaled softmax over that publication's
-affiliation-type similarity scores. These per-publication distributions are
-summed to produce a year-level affiliation-type vector.
+affiliation types into yearly distributions. For each year, it sums positive
+semantic similarity scores for each affiliation type across publications to
+produce a year-level affiliation-type vector. It also writes a normalized
+companion matrix where each year column sums to 1.0.
 
 The result is written to a CSV file with one row per affiliation type and one
 column per year.
@@ -16,16 +16,15 @@ Example:
     python affiliation_type_year_distribution.py \
         --db 2025_11_09_researchgate.sqlite \
         --start-year 2015 \
-        --end-year 2020 \
-        --temperature 0.3 \
-        --csv out.csv
+        --end-year 2020
 """
 
 import argparse
 import csv
+from datetime import datetime
 
 import numpy as np
-from sqlalchemy import create_engine, event, select
+from sqlalchemy import create_engine, event, func, select
 from sqlalchemy.orm import Session
 
 from models import (
@@ -84,38 +83,34 @@ def _load_affiliation_types(session: Session):
     return aff_type_ids, aff_type_text_by_id, aff_type_index_by_id
 
 
-def year_vector(session: Session, year: int, temperature: float):
+def year_vector(
+    session: Session,
+    year: int,
+    aff_type_ids_all,
+    aff_type_index_by_id: dict[int, int],
+):
     """Compute a year-level affiliation-type distribution vector.
 
-    For each publication in the specified year:
-        1. Collects (affiliation_type_id, semantic_similarity) pairs.
-        2. Applies temperature-scaled softmax to the similarity scores.
-        3. Accumulates the resulting weights into a year-level vector.
+    For each publication in the specified year, this function adds each positive
+    affiliation-type semantic similarity score to the year-level type total.
 
     Args:
         session: An active SQLAlchemy session.
         year: Publication year to aggregate.
-        temperature: Softmax temperature parameter controlling sharpness
-            of the per-publication distribution.
+        aff_type_ids_all: Ordered affiliation type IDs.
+        aff_type_index_by_id: ID -> dense index mapping.
 
     Returns:
-        tuple:
-            aff_type_ids_all (np.ndarray): Ordered affiliation type IDs.
-            aff_type_text_by_id (dict[int, str]): ID -> short name mapping.
-            year_aff_vector (np.ndarray): Summed softmax weights per affiliation type.
+        np.ndarray: Summed positive semantic similarity per affiliation type.
     """
-    print(f"[year_vector] start year={year} temperature={temperature}")
+    print(f"[year_vector] start year={year}")
 
-    aff_type_ids_all, aff_type_text_by_id, aff_type_index_by_id = (
-        _load_affiliation_types(session)
-    )
     year_aff_vector = np.zeros(len(aff_type_ids_all), dtype=np.float64)
 
     query = (
         select(
-            AffiliationTypeToPublicationDistance.publication_id,
             AffiliationTypeToPublicationDistance.affiliation_type_id,
-            AffiliationTypeToPublicationDistance.semantic_similarity,
+            func.sum(AffiliationTypeToPublicationDistance.semantic_similarity),
         )
         .join(
             Publication,
@@ -123,57 +118,52 @@ def year_vector(session: Session, year: int, temperature: float):
             == AffiliationTypeToPublicationDistance.publication_id,
         )
         .where(Publication.publication_year == year)
-        .order_by(
-            AffiliationTypeToPublicationDistance.publication_id,
-            AffiliationTypeToPublicationDistance.affiliation_type_id,
-        )
+        .where(AffiliationTypeToPublicationDistance.semantic_similarity > 0.0)
+        .group_by(AffiliationTypeToPublicationDistance.affiliation_type_id)
+        .order_by(AffiliationTypeToPublicationDistance.affiliation_type_id)
     )
 
-    rows = session.execute(query)
-
-    current_publication_id = None
-    publication_aff_type_ids: list[int] = []
-    publication_scores: list[float] = []
-
-    def flush():
-        """Aggregate accumulated rows for a single publication."""
-        if not publication_scores:
-            return
-
-        scores = np.array(publication_scores, dtype=np.float64)
-        scores = np.maximum(scores, 0.0)
-        scores = scores / temperature
-
-        max_score = float(scores.max())
-        exponentials = np.exp(scores - max_score)
-        denom = float(exponentials.sum())
-        if denom == 0.0:
-            return
-
-        weights = exponentials / denom
-
-        for aff_type_id, weight in zip(
-            publication_aff_type_ids, weights, strict=True
-        ):
-            year_aff_vector[aff_type_index_by_id[aff_type_id]] += float(weight)
-
-    for publication_id, aff_type_id, semantic_similarity in rows:
-        if current_publication_id is None:
-            current_publication_id = publication_id
-
-        if publication_id != current_publication_id:
-            flush()
-            current_publication_id = publication_id
-            publication_aff_type_ids = []
-            publication_scores = []
-
-        publication_aff_type_ids.append(int(aff_type_id))
-        publication_scores.append(float(semantic_similarity))
-
-    flush()
+    for aff_type_id, semantic_similarity_sum in session.execute(query):
+        year_aff_vector[aff_type_index_by_id[aff_type_id]] = float(
+            semantic_similarity_sum or 0.0
+        )
 
     print(f"[year_vector] done year={year}")
-    return aff_type_ids_all, aff_type_text_by_id, year_aff_vector
+    return year_aff_vector
+
+
+def timestamp_suffix() -> str:
+    return datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+
+
+def normalize_year_columns(year_matrix: np.ndarray) -> np.ndarray:
+    column_sums = year_matrix.sum(axis=0)
+    normalized = np.zeros_like(year_matrix)
+    nonzero_columns = column_sums != 0.0
+    normalized[:, nonzero_columns] = (
+        year_matrix[:, nonzero_columns] / column_sums[nonzero_columns]
+    )
+    return normalized
+
+
+def write_year_matrix_csv(
+    path: str,
+    aff_type_ids,
+    aff_type_text_by_id,
+    years: list[int],
+    year_matrix: np.ndarray,
+) -> None:
+    with open(path, "w", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(["affiliation_type_id", "affiliation_type_short_name", *years])
+        for i, aff_type_id in enumerate(aff_type_ids):
+            writer.writerow(
+                [
+                    int(aff_type_id),
+                    aff_type_text_by_id[int(aff_type_id)],
+                    *year_matrix[i, :].tolist(),
+                ]
+            )
 
 
 def main():
@@ -193,11 +183,12 @@ def main():
     parser.add_argument("--db", default=DB_PATH)
     parser.add_argument("--start-year", type=int, required=True)
     parser.add_argument("--end-year", type=int, required=True)
-    parser.add_argument(
-        "--csv", default="affiliation_type_distribution_by_year.csv"
-    )
-    parser.add_argument("--temperature", type=float, default=0.3)
     args = parser.parse_args()
+    timestamp = timestamp_suffix()
+    csv_path = f"analyze_affiliation_vector_by_year_{timestamp}.csv"
+    normalized_csv_path = (
+        f"analyze_affiliation_vector_by_year_normalized_{timestamp}.csv"
+    )
 
     engine = create_engine(
         f"sqlite:///{args.db}",
@@ -209,38 +200,37 @@ def main():
     years = list(range(args.start_year, args.end_year + 1))
 
     with Session(engine) as session:
-        aff_type_ids, aff_type_text_by_id, year_vec0 = year_vector(
-            session,
-            year=years[0],
-            temperature=args.temperature,
+        aff_type_ids, aff_type_text_by_id, aff_type_index_by_id = (
+            _load_affiliation_types(session)
         )
 
         year_matrix = np.zeros(
             (len(aff_type_ids), len(years)), dtype=np.float64
         )
-        year_matrix[:, 0] = year_vec0
 
-        for year_index, year_value in enumerate(years[1:], start=1):
-            _, _, year_vec = year_vector(
+        for year_index, year_value in enumerate(years):
+            year_vec = year_vector(
                 session,
                 year=year_value,
-                temperature=args.temperature,
+                aff_type_ids_all=aff_type_ids,
+                aff_type_index_by_id=aff_type_index_by_id,
             )
             year_matrix[:, year_index] = year_vec
 
-    with open(args.csv, "w", newline="") as file:
-        writer = csv.writer(file)
-        writer.writerow(
-            ["affiliation_type_id", "affiliation_type_short_name", *years]
-        )
-        for i, aff_type_id in enumerate(aff_type_ids):
-            writer.writerow(
-                [
-                    int(aff_type_id),
-                    aff_type_text_by_id[int(aff_type_id)],
-                    *year_matrix[i, :].tolist(),
-                ]
-            )
+    write_year_matrix_csv(
+        csv_path,
+        aff_type_ids,
+        aff_type_text_by_id,
+        years,
+        year_matrix,
+    )
+    write_year_matrix_csv(
+        normalized_csv_path,
+        aff_type_ids,
+        aff_type_text_by_id,
+        years,
+        normalize_year_columns(year_matrix),
+    )
 
     for year_index, year_value in enumerate(years):
         vec = year_matrix[:, year_index]

--- a/analyze_affiliation_vector_by_year.py
+++ b/analyze_affiliation_vector_by_year.py
@@ -22,6 +22,7 @@ Example:
 import argparse
 import csv
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 from sqlalchemy import create_engine, event, func, select
@@ -34,6 +35,7 @@ from models import (
 )
 
 DB_PATH = "2025_11_09_researchgate.sqlite"
+REPORTS_DIR = Path("topic_mapping_reports")
 
 
 def _set_sqlite_pragma(dbapi_connection, _):
@@ -185,9 +187,10 @@ def main():
     parser.add_argument("--end-year", type=int, required=True)
     args = parser.parse_args()
     timestamp = timestamp_suffix()
-    csv_path = f"analyze_affiliation_vector_by_year_{timestamp}.csv"
+    REPORTS_DIR.mkdir(exist_ok=True)
+    csv_path = REPORTS_DIR / f"analyze_affiliation_vector_by_year_{timestamp}.csv"
     normalized_csv_path = (
-        f"analyze_affiliation_vector_by_year_normalized_{timestamp}.csv"
+        REPORTS_DIR / f"analyze_affiliation_vector_by_year_normalized_{timestamp}.csv"
     )
 
     engine = create_engine(

--- a/analyze_satellites_used_together.py
+++ b/analyze_satellites_used_together.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import csv
 import logging
+from pathlib import Path
 
 from tqdm import tqdm
 from sqlalchemy import create_engine, event, select, func, and_
@@ -22,6 +23,7 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 db_path = "2025_11_09_researchgate.sqlite"
+reports_dir = Path("topic_mapping_reports")
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
@@ -37,7 +39,8 @@ event.listen(engine, "connect", _set_sqlite_pragma)
 Base.metadata.create_all(engine)
 
 timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-output_path = f"satellite_pair_counts_{timestamp}.csv"
+reports_dir.mkdir(exist_ok=True)
+output_path = reports_dir / f"satellite_pair_counts_{timestamp}.csv"
 
 pts1 = aliased(PublicationToSatellite)
 pts2 = aliased(PublicationToSatellite)

--- a/analyze_sensors_to_topics.py
+++ b/analyze_sensors_to_topics.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import csv
 import logging
+from pathlib import Path
 
 from tqdm import tqdm
 from sqlalchemy import create_engine, event, select
@@ -24,6 +25,7 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 db_path = "2025_11_09_researchgate.sqlite"
+reports_dir = Path("topic_mapping_reports")
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
@@ -104,7 +106,8 @@ with Session(engine) as session:
             matrix[topic_name][sensor_names[sensor_idx]] += semantic_similarity
 
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    output_path = f"sensor_to_topic_closeness_{timestamp}.csv"
+    reports_dir.mkdir(exist_ok=True)
+    output_path = reports_dir / f"sensor_to_topic_closeness_{timestamp}.csv"
 
     logging.info("Writing CSV to %s", output_path)
     with open(output_path, "w", newline="", encoding="utf-8") as f:

--- a/analyze_sensors_used_together.py
+++ b/analyze_sensors_used_together.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import csv
 import logging
+from pathlib import Path
 
 from tqdm import tqdm
 from sqlalchemy import create_engine, event, select, func, and_
@@ -22,6 +23,7 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 db_path = "2025_11_09_researchgate.sqlite"
+reports_dir = Path("topic_mapping_reports")
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
@@ -37,7 +39,8 @@ event.listen(engine, "connect", _set_sqlite_pragma)
 Base.metadata.create_all(engine)
 
 timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-output_path = f"data_type_pair_counts_{timestamp}.csv"
+reports_dir.mkdir(exist_ok=True)
+output_path = reports_dir / f"data_type_pair_counts_{timestamp}.csv"
 
 ptd1 = aliased(PublicationToDataType)
 ptd2 = aliased(PublicationToDataType)

--- a/analyze_subject_vector_by_year.py
+++ b/analyze_subject_vector_by_year.py
@@ -24,6 +24,7 @@ Notes:
 import argparse
 import csv
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 from sqlalchemy import create_engine, event, func, select
@@ -32,6 +33,7 @@ from sqlalchemy.orm import Session
 from models import BaseTopics, BaseTopicToPublicationDistance, Publication
 
 DB_PATH = "2025_11_09_researchgate.sqlite"
+REPORTS_DIR = Path("topic_mapping_reports")
 
 
 engine = create_engine(
@@ -245,8 +247,11 @@ def main():
     argument_parser.add_argument("--end-year", type=int, required=True)
     args = argument_parser.parse_args()
     timestamp = timestamp_suffix()
-    csv_path = f"subject_vector_by_year_{timestamp}.csv"
-    normalized_csv_path = f"analyze_subject_vector_by_year_normalized_{timestamp}.csv"
+    REPORTS_DIR.mkdir(exist_ok=True)
+    csv_path = REPORTS_DIR / f"subject_vector_by_year_{timestamp}.csv"
+    normalized_csv_path = (
+        REPORTS_DIR / f"analyze_subject_vector_by_year_normalized_{timestamp}.csv"
+    )
 
     engine = create_engine(
         f"sqlite:///{args.db}",


### PR DESCRIPTION
## Summary
- Refactors `analyze_affiliation_vector_by_year.py` to aggregate positive `semantic_similarity` values by year directly
- Adds timestamped raw and normalized affiliation vector CSV outputs named after the script
- Updates `analyze_affiliation_country_subject_year.py` to use year-to-second timestamps, ignore non-positive similarities when picking top subject/affiliation mappings, and write a normalized `country_vs_year` CSV

## Validation
- `python -m py_compile analyze_affiliation_vector_by_year.py analyze_affiliation_country_subject_year.py`

Fixes #34