### PR TITLE
Write analyze outputs to topic mapping reports

### DIFF
--- a/analyze_affiliation_vector_by_year.py
+++ b/analyze_affiliation_vector_by_year.py
@@ -22,6 +22,7 @@ Example:
 import argparse
 import csv
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 from sqlalchemy import create_engine, event, func, select
@@ -34,6 +35,7 @@ from models import (
 )
 
 DB_PATH = "2025_11_09_researchgate.sqlite"
+REPORTS_DIR = Path("topic_mapping_reports")
 
 
 def _set_sqlite_pragma(dbapi_connection, _):
@@ -185,9 +187,10 @@ def main():
     parser.add_argument("--end-year", type=int, required=True)
     args = parser.parse_args()
     timestamp = timestamp_suffix()
-    csv_path = f"analyze_affiliation_vector_by_year_{timestamp}.csv"
+    REPORTS_DIR.mkdir(exist_ok=True)
+    csv_path = REPORTS_DIR / f"analyze_affiliation_vector_by_year_{timestamp}.csv"
     normalized_csv_path = (
-        f"analyze_affiliation_vector_by_year_normalized_{timestamp}.csv"
+        REPORTS_DIR / f"analyze_affiliation_vector_by_year_normalized_{timestamp}.csv"
     )
 
     engine = create_engine(

--- a/analyze_satellites_used_together.py
+++ b/analyze_satellites_used_together.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import csv
 import logging
+from pathlib import Path
 
 from tqdm import tqdm
 from sqlalchemy import create_engine, event, select, func, and_
@@ -22,6 +23,7 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 db_path = "2025_11_09_researchgate.sqlite"
+reports_dir = Path("topic_mapping_reports")
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
@@ -37,7 +39,8 @@ event.listen(engine, "connect", _set_sqlite_pragma)
 Base.metadata.create_all(engine)
 
 timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-output_path = f"satellite_pair_counts_{timestamp}.csv"
+reports_dir.mkdir(exist_ok=True)
+output_path = reports_dir / f"satellite_pair_counts_{timestamp}.csv"
 
 pts1 = aliased(PublicationToSatellite)
 pts2 = aliased(PublicationToSatellite)

--- a/analyze_sensors_to_topics.py
+++ b/analyze_sensors_to_topics.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import csv
 import logging
+from pathlib import Path
 
 from tqdm import tqdm
 from sqlalchemy import create_engine, event, select
@@ -24,6 +25,7 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 db_path = "2025_11_09_researchgate.sqlite"
+reports_dir = Path("topic_mapping_reports")
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
@@ -104,7 +106,8 @@ with Session(engine) as session:
             matrix[topic_name][sensor_names[sensor_idx]] += semantic_similarity
 
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    output_path = f"sensor_to_topic_closeness_{timestamp}.csv"
+    reports_dir.mkdir(exist_ok=True)
+    output_path = reports_dir / f"sensor_to_topic_closeness_{timestamp}.csv"
 
     logging.info("Writing CSV to %s", output_path)
     with open(output_path, "w", newline="", encoding="utf-8") as f:

--- a/analyze_sensors_used_together.py
+++ b/analyze_sensors_used_together.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import csv
 import logging
+from pathlib import Path
 
 from tqdm import tqdm
 from sqlalchemy import create_engine, event, select, func, and_
@@ -22,6 +23,7 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 db_path = "2025_11_09_researchgate.sqlite"
+reports_dir = Path("topic_mapping_reports")
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
@@ -37,7 +39,8 @@ event.listen(engine, "connect", _set_sqlite_pragma)
 Base.metadata.create_all(engine)
 
 timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-output_path = f"data_type_pair_counts_{timestamp}.csv"
+reports_dir.mkdir(exist_ok=True)
+output_path = reports_dir / f"data_type_pair_counts_{timestamp}.csv"
 
 ptd1 = aliased(PublicationToDataType)
 ptd2 = aliased(PublicationToDataType)

--- a/analyze_subject_vector_by_year.py
+++ b/analyze_subject_vector_by_year.py
@@ -24,6 +24,7 @@ Notes:
 import argparse
 import csv
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 from sqlalchemy import create_engine, event, func, select
@@ -32,6 +33,7 @@ from sqlalchemy.orm import Session
 from models import BaseTopics, BaseTopicToPublicationDistance, Publication
 
 DB_PATH = "2025_11_09_researchgate.sqlite"
+REPORTS_DIR = Path("topic_mapping_reports")
 
 
 engine = create_engine(
@@ -245,8 +247,11 @@ def main():
     argument_parser.add_argument("--end-year", type=int, required=True)
     args = argument_parser.parse_args()
     timestamp = timestamp_suffix()
-    csv_path = f"subject_vector_by_year_{timestamp}.csv"
-    normalized_csv_path = f"analyze_subject_vector_by_year_normalized_{timestamp}.csv"
+    REPORTS_DIR.mkdir(exist_ok=True)
+    csv_path = REPORTS_DIR / f"subject_vector_by_year_{timestamp}.csv"
+    normalized_csv_path = (
+        REPORTS_DIR / f"analyze_subject_vector_by_year_normalized_{timestamp}.csv"
+    )
 
     engine = create_engine(
         f"sqlite:///{args.db}",


### PR DESCRIPTION
## Summary
- Routes remaining root-level analyze CSV outputs into `topic_mapping_reports`
- Creates the reports directory before writing from each updated script
- Preserves the existing timestamped filenames under the reports directory

## Updated scripts
- `analyze_subject_vector_by_year.py`
- `analyze_affiliation_vector_by_year.py`
- `analyze_sensors_to_topics.py`
- `analyze_satellites_used_together.py`
- `analyze_sensors_used_together.py`

## Validation
- `python -m py_compile analyze_affiliation_country_subject_year.py analyze_affiliation_vector_by_year.py analyze_satellites_used_together.py analyze_sat_and_data_types_in_abstracts.py analyze_sensors_to_topics.py analyze_sensors_used_together.py analyze_subject_vector_by_year.py`

Fixes #36