### PR TITLE
Refactor country vs subject report to use soft weights

### DIFF
--- a/analyze_affiliation_country_subject_year.py
+++ b/analyze_affiliation_country_subject_year.py
@@ -128,17 +128,24 @@ reports = [
         "Country",
         "Subject",
         "Country vs subject",
-        True,
-        common_ctes
+        False,
+        soft_weight_ctes
         + """
+        , country_map as (
+            select distinct
+                ppal.publication_id,
+                l.name as country
+            from publication_primary_author_locations ppal
+            join locations l on l.id = ppal.location_id
+            where lower(l.type) = 'country'
+        )
         select
             cm.country as row_label,
-            ts.subject as column_label,
-            count(distinct p.id) as count
-        from publications p
-        join country_map cm on cm.publication_id = p.id
-        join top_subject ts on ts.publication_id = p.id
-        group by cm.country, ts.subject
+            ps.subject as column_label,
+            sum(ps.subject_weight) as count
+        from country_map cm
+        join positive_subject ps on ps.publication_id = cm.publication_id
+        group by cm.country, ps.subject
         """,
     ),
     (


### PR DESCRIPTION
## Summary
- Refactors country_vs_subject in analyze_affiliation_country_subject_year.py to sum all positive subject semantic weights.
- Stops assigning each publication-country pair only to the single max/top subject.
- Keeps the existing timestamped topic_mapping_reports output pattern.

## Method
For each publication, all subject similarities greater than zero are retained. Country associations are identified from the matched publication country locations. For every publication-country association, the script adds each positive subject similarity to that country's subject total. This means a publication can contribute to multiple subject columns and multiple country rows when it has positive semantic signal across several subjects and author-location matches across more than one country.

## Verification
- python -m py_compile analyze_affiliation_country_subject_year.py

Fixes #48