### PR TITLE
Use cleaned affiliations for author distance embeddings

### DIFF
--- a/populate_author_affiliation_type_distances.py
+++ b/populate_author_affiliation_type_distances.py
@@ -5,7 +5,7 @@ import argparse
 import numpy as np
 from dotenv import load_dotenv
 from openai import OpenAI
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, func, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 from tqdm import tqdm
@@ -71,10 +71,14 @@ def load_affiliation_types(session: Session) -> tuple[list[int], np.ndarray]:
 def load_pending_author_locations(
     session: Session, limit: int | None
 ) -> list[tuple[int, str]]:
+    affiliation_embedding_text = func.coalesce(
+        func.nullif(PublicationAuthorLocation.cleaned_affiliation_text, ""),
+        PublicationAuthorLocation.affiliation_text,
+    )
     query = (
         select(
             PublicationAuthorLocation.id,
-            PublicationAuthorLocation.affiliation_text,
+            affiliation_embedding_text,
         )
         .outerjoin(
             PublicationAuthorLocationAffiliationTypeDistance,

--- a/populate_author_affiliation_type_distances.py
+++ b/populate_author_affiliation_type_distances.py
@@ -5,7 +5,7 @@ import argparse
 import numpy as np
 from dotenv import load_dotenv
 from openai import OpenAI
-from sqlalchemy import create_engine, func, select
+from sqlalchemy import create_engine, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 from tqdm import tqdm
@@ -71,14 +71,10 @@ def load_affiliation_types(session: Session) -> tuple[list[int], np.ndarray]:
 def load_pending_author_locations(
     session: Session, limit: int | None
 ) -> list[tuple[int, str]]:
-    affiliation_embedding_text = func.coalesce(
-        func.nullif(PublicationAuthorLocation.cleaned_affiliation_text, ""),
-        PublicationAuthorLocation.affiliation_text,
-    )
     query = (
         select(
             PublicationAuthorLocation.id,
-            affiliation_embedding_text,
+            PublicationAuthorLocation.cleaned_affiliation_text,
         )
         .outerjoin(
             PublicationAuthorLocationAffiliationTypeDistance,


### PR DESCRIPTION
## Summary
- Refactors populate_author_affiliation_type_distances.py to embed cleaned author affiliation text when available.
- Falls back to raw ffiliation_text if cleaned_affiliation_text is null or blank.
- Leaves the existing pending-row behavior intact, so it does not add any recompute/overwrite path.

## Implementation
The loader now selects:

`python
coalesce(nullif(cleaned_affiliation_text, ''), affiliation_text)
`

as the text sent to OpenAI embeddings.

## Verification
- python -m py_compile populate_author_affiliation_type_distances.py

Re #59