### PR TITLE
Power-normalize affiliation vectors

### DIFF
--- a/affiliation_vector_transform.py
+++ b/affiliation_vector_transform.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def power_normalize(values, power: float = 2.0) -> np.ndarray:
+    """Clip negatives, apply a power transform, and normalize to sum to 1.
+
+    The transform emphasizes larger semantic similarity values while preserving
+    each vector as a proportional distribution. If every clipped value is zero,
+    the all-zero vector is returned.
+    """
+    vector = np.asarray(values, dtype=np.float64)
+    transformed = np.power(np.maximum(vector, 0.0), power)
+    denominator = float(transformed.sum())
+    if denominator == 0.0:
+        return np.zeros_like(transformed)
+    return transformed / denominator

--- a/affiliation_vector_transform.py
+++ b/affiliation_vector_transform.py
@@ -4,11 +4,22 @@ import numpy as np
 
 
 def power_normalize(values, power: float = 2.0) -> np.ndarray:
-    """Clip negatives, apply a power transform, and normalize to sum to 1.
+    """Apply a clipped power transform and normalize the vector.
 
-    The transform emphasizes larger semantic similarity values while preserving
-    each vector as a proportional distribution. If every clipped value is zero,
-    the all-zero vector is returned.
+    Negative values are clipped to zero before the power transform is applied.
+    The transformed values are then divided by their sum so the output can be
+    interpreted as a proportional distribution. If every clipped value is zero,
+    this returns an all-zero vector with the same shape as the input.
+
+    Args:
+        values: Sequence or array of raw similarity values.
+        power: Exponent to apply after clipping values to zero. Values greater
+            than 1.0 emphasize larger dimensions and suppress smaller ones.
+
+    Returns:
+        A NumPy float64 array containing the power-transformed normalized
+        values. The returned vector sums to 1.0 unless all clipped input values
+        are zero, in which case it sums to 0.0.
     """
     vector = np.asarray(values, dtype=np.float64)
     transformed = np.power(np.maximum(vector, 0.0), power)

--- a/affiliation_vector_transform.py
+++ b/affiliation_vector_transform.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 
-def power_normalize(values, power: float = 2.0) -> np.ndarray:
+def power_normalize(values, power: float = 4.0) -> np.ndarray:
     """Apply a clipped power transform and normalize the vector.
 
     Negative values are clipped to zero before the power transform is applied.

--- a/analyze_affiliation_vector_by_year.py
+++ b/analyze_affiliation_vector_by_year.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 Compute per-year affiliation-type distributions for publications in a SQLite database.
 
 This script aggregates semantic similarity scores between publications and
-affiliation types into yearly distributions. For each year, it sums positive
-semantic similarity scores for each affiliation type across publications to
-produce a year-level affiliation-type vector. It also writes a normalized
-companion matrix where each year column sums to 1.0.
+affiliation types into yearly distributions. For each publication, it clips
+negative values to zero, squares each affiliation-type similarity, and
+normalizes the resulting vector so the publication contributes total weight 1.
+It sums those transformed publication-level vectors to produce a year-level
+affiliation-type vector. It also writes a normalized companion matrix where
+each year column sums to 1.0.
 
 The result is written to a CSV file with one row per affiliation type and one
 column per year.
@@ -25,9 +27,10 @@ from datetime import datetime
 from pathlib import Path
 
 import numpy as np
-from sqlalchemy import create_engine, event, func, select
+from sqlalchemy import create_engine, event, select
 from sqlalchemy.orm import Session
 
+from affiliation_vector_transform import power_normalize
 from models import (
     AffiliationType,
     AffiliationTypeToPublicationDistance,
@@ -93,8 +96,9 @@ def year_vector(
 ):
     """Compute a year-level affiliation-type distribution vector.
 
-    For each publication in the specified year, this function adds each positive
-    affiliation-type semantic similarity score to the year-level type total.
+    For each publication in the specified year, this function transforms the
+    publication's affiliation-type vector by clipping negative values to zero,
+    squaring each value, and normalizing the vector to sum to 1.
 
     Args:
         session: An active SQLAlchemy session.
@@ -103,7 +107,7 @@ def year_vector(
         aff_type_index_by_id: ID -> dense index mapping.
 
     Returns:
-        np.ndarray: Summed positive semantic similarity per affiliation type.
+        np.ndarray: Summed normalized affiliation-type weights.
     """
     print(f"[year_vector] start year={year}")
 
@@ -111,8 +115,9 @@ def year_vector(
 
     query = (
         select(
+            AffiliationTypeToPublicationDistance.publication_id,
             AffiliationTypeToPublicationDistance.affiliation_type_id,
-            func.sum(AffiliationTypeToPublicationDistance.semantic_similarity),
+            AffiliationTypeToPublicationDistance.semantic_similarity,
         )
         .join(
             Publication,
@@ -120,17 +125,46 @@ def year_vector(
             == AffiliationTypeToPublicationDistance.publication_id,
         )
         .where(Publication.publication_year == year)
-        .where(AffiliationTypeToPublicationDistance.semantic_similarity > 0.0)
-        .group_by(AffiliationTypeToPublicationDistance.affiliation_type_id)
-        .order_by(AffiliationTypeToPublicationDistance.affiliation_type_id)
+        .order_by(
+            AffiliationTypeToPublicationDistance.publication_id,
+            AffiliationTypeToPublicationDistance.affiliation_type_id,
+        )
     )
 
-    for aff_type_id, semantic_similarity_sum in session.execute(query):
-        year_aff_vector[aff_type_index_by_id[aff_type_id]] = float(
-            semantic_similarity_sum or 0.0
-        )
+    current_publication_id = None
+    publication_aff_type_ids: list[int] = []
+    publication_scores: list[float] = []
+    publication_count = 0
 
-    print(f"[year_vector] done year={year}")
+    def flush() -> None:
+        nonlocal publication_count
+
+        if not publication_scores:
+            return
+
+        publication_count += 1
+        weights = power_normalize(publication_scores)
+        for aff_type_id, weight in zip(
+            publication_aff_type_ids, weights, strict=True
+        ):
+            year_aff_vector[aff_type_index_by_id[aff_type_id]] += float(weight)
+
+    for publication_id, aff_type_id, semantic_similarity in session.execute(query):
+        if current_publication_id is None:
+            current_publication_id = publication_id
+
+        if publication_id != current_publication_id:
+            flush()
+            current_publication_id = publication_id
+            publication_aff_type_ids = []
+            publication_scores = []
+
+        publication_aff_type_ids.append(int(aff_type_id))
+        publication_scores.append(float(semantic_similarity))
+
+    flush()
+
+    print(f"[year_vector] done year={year} publications={publication_count}")
     return year_aff_vector
 
 

--- a/analyze_affiliation_vector_by_year.py
+++ b/analyze_affiliation_vector_by_year.py
@@ -5,8 +5,9 @@ Compute per-year affiliation-type distributions for publications in a SQLite dat
 
 This script aggregates semantic similarity scores between publications and
 affiliation types into yearly distributions. For each publication, it clips
-negative values to zero, squares each affiliation-type similarity, and
-normalizes the resulting vector so the publication contributes total weight 1.
+negative values to zero, raises each affiliation-type similarity to the fourth
+power, and normalizes the resulting vector so the publication contributes total
+weight 1.
 It sums those transformed publication-level vectors to produce a year-level
 affiliation-type vector. It also writes a normalized companion matrix where
 each year column sums to 1.0.

--- a/analyze_subject_vector_by_year.py
+++ b/analyze_subject_vector_by_year.py
@@ -32,6 +32,7 @@ from sqlalchemy import create_engine, event, select
 from sqlalchemy.orm import Session
 from tqdm.auto import tqdm
 
+from affiliation_vector_transform import power_normalize
 from models import BaseTopics, BaseTopicToPublicationDistance, Publication
 
 DB_PATH = "2025_11_09_researchgate.sqlite"
@@ -163,15 +164,7 @@ def year_vector(
         publication_progress.update(1)
         publication_progress.set_postfix(rows=row_counter, refresh=False)
 
-        scores = np.array(publication_scores, dtype=np.float64)
-        scores = np.maximum(scores, 0.0)
-        weights = np.square(scores)
-        denominator = float(weights.sum())
-        if denominator == 0.0:
-            return
-
-        weights = weights / denominator
-
+        weights = power_normalize(publication_scores)
         for base_topic_id, weight in zip(
             publication_base_topic_ids, weights, strict=True
         ):

--- a/analyze_subject_vector_by_year.py
+++ b/analyze_subject_vector_by_year.py
@@ -5,9 +5,10 @@ Compute per-year base-topic distributions for publications stored in a SQLite da
 
 This script queries a ResearchGate-derived SQLite database containing publications, base topics,
 and per-publication distances (semantic similarities) to base topics. For each publication in a
-given year, it squares each nonnegative base-topic similarity and normalizes the squared vector
-so the publication contributes a total topic weight of 1. The normalized publication-level
-vectors are summed across all publications in the year to form a year-level topic vector. It
+given year, it raises each nonnegative base-topic similarity to the fourth power
+and normalizes the transformed vector so the publication contributes a total
+topic weight of 1. The normalized publication-level vectors are summed across
+all publications in the year to form a year-level topic vector. It
 also writes a normalized companion matrix where each year column sums to 1.0.
 
 The script can compute vectors across a year range and write a CSV matrix with one row per base
@@ -101,8 +102,8 @@ def year_vector(
 
     For each publication in the specified year, this function:
       1) collects (base_topic_id, semantic_similarity) pairs
-      2) clamps negative similarities to 0, then squares each score
-      3) normalizes the squared scores so the publication-level vector sums to 1
+      2) clamps negative similarities to 0, then raises each score to the fourth power
+      3) normalizes the transformed scores so the publication-level vector sums to 1
       4) accumulates the resulting weights into a year-level vector over base topics
 
     Args:

--- a/sample_author_affiliation_vectors.py
+++ b/sample_author_affiliation_vectors.py
@@ -14,6 +14,8 @@ import logging
 from pathlib import Path
 import sqlite3
 
+from affiliation_vector_transform import power_normalize
+
 
 DB_PATH = "2025_11_09_researchgate.sqlite"
 REPORTS_DIR = Path("topic_mapping_reports")
@@ -63,6 +65,14 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument("--db", default=DB_PATH)
+    parser.add_argument(
+        "--include-transformed",
+        action="store_true",
+        help=(
+            "Append squared-and-normalized affiliation-type weights for comparing "
+            "raw vectors with the preferred nonlinear transform."
+        ),
+    )
     parser.add_argument(
         "--output",
         type=Path,
@@ -180,14 +190,22 @@ def write_csv(
     author_locations: dict[int, sqlite3.Row],
     vectors: dict[int, dict[int, float]],
     affiliation_types: list[tuple[int, str]],
+    include_transformed: bool,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    transformed_headers = []
+    if include_transformed:
+        transformed_headers = [
+            f"transformed_{short_name}" for _, short_name in affiliation_types
+        ]
+
     headers = [
         "author_name",
         "author_affiliation",
         "publication_id",
         "publication_author_location_id",
         *[short_name for _, short_name in affiliation_types],
+        *transformed_headers,
     ]
 
     with open(path, "w", newline="", encoding="utf-8") as file:
@@ -196,16 +214,26 @@ def write_csv(
         for author_location_id in author_location_ids:
             author_location = author_locations[author_location_id]
             vector = vectors.get(author_location_id, {})
+            raw_values = [
+                vector.get(affiliation_type_id, "")
+                for affiliation_type_id, _ in affiliation_types
+            ]
+            transformed_values = []
+            if include_transformed:
+                numeric_raw_values = [
+                    vector.get(affiliation_type_id, 0.0)
+                    for affiliation_type_id, _ in affiliation_types
+                ]
+                transformed_values = power_normalize(numeric_raw_values).tolist()
+
             writer.writerow(
                 [
                     author_location["author_name"],
                     author_location["affiliation_text"],
                     author_location["publication_id"],
                     author_location["id"],
-                    *[
-                        vector.get(affiliation_type_id, "")
-                        for affiliation_type_id, _ in affiliation_types
-                    ],
+                    *raw_values,
+                    *transformed_values,
                 ]
             )
 
@@ -244,6 +272,7 @@ def main() -> None:
         author_locations,
         vectors,
         affiliation_types,
+        args.include_transformed,
     )
     print(output_path)
 

--- a/sample_author_affiliation_vectors.py
+++ b/sample_author_affiliation_vectors.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 """
-Sample author affiliations and export their affiliation-type similarity vectors.
+Sample author affiliations and export transformed affiliation-type vectors.
 
 Each output row represents one row from publication_author_locations. The vector
-columns come from publication_author_location_to_affiliation_type_distance.
+columns are power-normalized weights based on
+publication_author_location_to_affiliation_type_distance.
 """
 
 import argparse
@@ -42,8 +43,8 @@ def timestamp_suffix() -> str:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Export a sample of author affiliations with their classified "
-            "affiliation-type similarity vector."
+            "Export a sample of author affiliations with their transformed "
+            "affiliation-type weight vector."
         )
     )
     parser.add_argument(
@@ -65,14 +66,6 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument("--db", default=DB_PATH)
-    parser.add_argument(
-        "--include-transformed",
-        action="store_true",
-        help=(
-            "Append squared-and-normalized affiliation-type weights for comparing "
-            "raw vectors with the preferred nonlinear transform."
-        ),
-    )
     parser.add_argument(
         "--output",
         type=Path,
@@ -190,22 +183,14 @@ def write_csv(
     author_locations: dict[int, sqlite3.Row],
     vectors: dict[int, dict[int, float]],
     affiliation_types: list[tuple[int, str]],
-    include_transformed: bool,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    transformed_headers = []
-    if include_transformed:
-        transformed_headers = [
-            f"transformed_{short_name}" for _, short_name in affiliation_types
-        ]
-
     headers = [
         "author_name",
         "author_affiliation",
         "publication_id",
         "publication_author_location_id",
         *[short_name for _, short_name in affiliation_types],
-        *transformed_headers,
     ]
 
     with open(path, "w", newline="", encoding="utf-8") as file:
@@ -214,17 +199,11 @@ def write_csv(
         for author_location_id in author_location_ids:
             author_location = author_locations[author_location_id]
             vector = vectors.get(author_location_id, {})
-            raw_values = [
-                vector.get(affiliation_type_id, "")
+            source_values = [
+                vector.get(affiliation_type_id, 0.0)
                 for affiliation_type_id, _ in affiliation_types
             ]
-            transformed_values = []
-            if include_transformed:
-                numeric_raw_values = [
-                    vector.get(affiliation_type_id, 0.0)
-                    for affiliation_type_id, _ in affiliation_types
-                ]
-                transformed_values = power_normalize(numeric_raw_values).tolist()
+            transformed_values = power_normalize(source_values).tolist()
 
             writer.writerow(
                 [
@@ -232,7 +211,6 @@ def write_csv(
                     author_location["affiliation_text"],
                     author_location["publication_id"],
                     author_location["id"],
-                    *raw_values,
                     *transformed_values,
                 ]
             )
@@ -272,7 +250,6 @@ def main() -> None:
         author_locations,
         vectors,
         affiliation_types,
-        args.include_transformed,
     )
     print(output_path)
 


### PR DESCRIPTION
## Proposed solution
Use the same fourth-power-normalized distribution formula selected for subject vectors:

```text
x_i' = max(x_i, 0)^4 / sum_j max(x_j, 0)^4
```

If every clipped value is zero, the transformed vector remains all zeros. This more strongly suppresses weak/noisy similarities, emphasizes stronger affiliation classifications, and keeps each transformed vector interpretable as a proportional distribution.

## Scope
- Add `affiliation_vector_transform.power_normalize` as the shared formula, defaulting to a fourth-power transform.
- Reuse that helper from both `analyze_affiliation_vector_by_year.py` and `analyze_subject_vector_by_year.py` so the power-normalization logic is not duplicated.
- Apply the transform in `analyze_affiliation_vector_by_year.py` at analysis/reporting time, before yearly aggregation.
- Preserve stored semantic similarities as raw values; this does not change population scripts or database contents.
- Update `sample_author_affiliation_vectors.py` so sampled affiliation reports show transformed affiliation weights as the regular affiliation weight columns, without reporting the raw values separately.

## Validation
- `python -m py_compile affiliation_vector_transform.py analyze_affiliation_vector_by_year.py analyze_subject_vector_by_year.py sample_author_affiliation_vectors.py`
- `python sample_author_affiliation_vectors.py 2 --output topic_mapping_reports/sample_affiliation_power4_check.csv`
- `python -c "from affiliation_vector_transform import power_normalize; v=power_normalize([0.2,0.4,-1,0,0.1]); print([round(x, 6) for x in v.tolist()]); print(round(float(v.sum()), 6))"`
- `git diff --check`

Closes #53