### PR TITLE
Use power-normalized vectors in downstream reports

### DIFF
--- a/analyze_affiliation_country_subject_year.py
+++ b/analyze_affiliation_country_subject_year.py
@@ -3,8 +3,11 @@ import logging
 from pathlib import Path
 from time import perf_counter
 
+import numpy as np
 import pandas as pd
 from sqlalchemy import create_engine, text
+
+from affiliation_vector_transform import power_normalize
 
 try:
     from tqdm import tqdm
@@ -23,159 +26,54 @@ logger = logging.getLogger(__name__)
 
 out_dir.mkdir(exist_ok=True)
 
-# The database stores raw semantic similarities. These CTEs derive report-time
-# weights by clipping negatives, raising positives to the fourth power, and
-# normalizing each publication vector so it sums to 1.0 before aggregation.
-common_ctes = """
-with country_map as (
-    select distinct
-        ppal.publication_id,
-        l.name as country
-    from publication_primary_author_locations ppal
-    join locations l on l.id = ppal.location_id
-    where lower(l.type) = 'country'
-)
+COUNTRY_MAP_QUERY = """
+select distinct
+    ppal.publication_id,
+    l.name as country
+from publication_primary_author_locations ppal
+join locations l on l.id = ppal.location_id
+where lower(l.type) = 'country'
 """
 
-soft_weight_ctes = """
-with subject_power as (
-    select
-        btpd.publication_id,
-        bt.short_name as subject,
-        case
-            when btpd.semantic_similarity > 0
-            then btpd.semantic_similarity
-                * btpd.semantic_similarity
-                * btpd.semantic_similarity
-                * btpd.semantic_similarity
-            else 0
-        end as subject_power
-    from base_topic_to_pub_distance btpd
-    join base_topics bt on bt.id = btpd.base_topic_id
-),
-positive_subject as (
-    select
-        publication_id,
-        subject,
-        subject_power
-            / sum(subject_power) over (partition by publication_id)
-            as subject_weight
-    from subject_power
-    where subject_power > 0
-),
-affiliation_power as (
-    select
-        atpd.publication_id,
-        aft.short_name as affiliation_type,
-        case
-            when atpd.semantic_similarity > 0
-            then atpd.semantic_similarity
-                * atpd.semantic_similarity
-                * atpd.semantic_similarity
-                * atpd.semantic_similarity
-            else 0
-        end as affiliation_power
-    from affiliation_type_to_pub_distance atpd
-    join affiliation_types aft on aft.id = atpd.affiliation_type_id
-),
-positive_affiliation as (
-    select
-        publication_id,
-        affiliation_type,
-        affiliation_power
-            / sum(affiliation_power) over (partition by publication_id)
-            as affiliation_weight
-    from affiliation_power
-    where affiliation_power > 0
+RAW_SUBJECT_QUERY = """
+select
+    btpd.publication_id,
+    bt.short_name as label,
+    btpd.semantic_similarity
+from base_topic_to_pub_distance btpd
+join base_topics bt on bt.id = btpd.base_topic_id
+order by btpd.publication_id, btpd.base_topic_id
+"""
+
+RAW_AFFILIATION_QUERY = """
+select
+    atpd.publication_id,
+    aft.short_name as label,
+    atpd.semantic_similarity
+from affiliation_type_to_pub_distance atpd
+join affiliation_types aft on aft.id = atpd.affiliation_type_id
+order by atpd.publication_id, atpd.affiliation_type_id
+"""
+
+COUNTRY_VS_YEAR_QUERY = f"""
+with country_map as (
+    {COUNTRY_MAP_QUERY}
 )
+select
+    cm.country as row_label,
+    p.publication_year as column_label,
+    count(distinct p.id) as count
+from publications p
+join country_map cm on cm.publication_id = p.id
+where p.publication_year is not null
+group by cm.country, p.publication_year
 """
 
 reports = [
-    (
-        "affiliation_type_vs_subject",
-        "Affiliation type",
-        "Subject",
-        "Affiliation type vs subject",
-        False,
-        soft_weight_ctes
-        + """
-        select
-            pa.affiliation_type as row_label,
-            ps.subject as column_label,
-            sum(pa.affiliation_weight * ps.subject_weight) as count
-        from positive_affiliation pa
-        join positive_subject ps on ps.publication_id = pa.publication_id
-        group by pa.affiliation_type, ps.subject
-        """,
-    ),
-    (
-        "country_vs_year",
-        "Country",
-        "Year",
-        "Country vs year",
-        True,
-        common_ctes
-        + """
-        select
-            cm.country as row_label,
-            p.publication_year as column_label,
-            count(distinct p.id) as count
-        from publications p
-        join country_map cm on cm.publication_id = p.id
-        where p.publication_year is not null
-        group by cm.country, p.publication_year
-        """,
-    ),
-    (
-        "country_vs_subject",
-        "Country",
-        "Subject",
-        "Country vs subject",
-        False,
-        soft_weight_ctes
-        + """
-        , country_map as (
-            select distinct
-                ppal.publication_id,
-                l.name as country
-            from publication_primary_author_locations ppal
-            join locations l on l.id = ppal.location_id
-            where lower(l.type) = 'country'
-        )
-        select
-            cm.country as row_label,
-            ps.subject as column_label,
-            sum(ps.subject_weight) as count
-        from country_map cm
-        join positive_subject ps on ps.publication_id = cm.publication_id
-        group by cm.country, ps.subject
-        """,
-    ),
-    (
-        "country_vs_affiliation_type",
-        "Country",
-        "Affiliation type",
-        "Country vs affiliation type",
-        False,
-        soft_weight_ctes
-        + """
-        , country_map as (
-            select distinct
-                ppal.publication_id,
-                l.name as country
-            from publication_primary_author_locations ppal
-            join locations l on l.id = ppal.location_id
-            where lower(l.type) = 'country'
-        )
-        select
-            cm.country as row_label,
-            pa.affiliation_type as column_label,
-            sum(pa.affiliation_weight) as count
-        from country_map cm
-        join positive_affiliation pa on pa.publication_id = cm.publication_id
-        group by cm.country, pa.affiliation_type
-        """,
-    ),
+    ("affiliation_type_vs_subject", "Affiliation type", "Subject", False),
+    ("country_vs_year", "Country", "Year", True),
+    ("country_vs_subject", "Country", "Subject", False),
+    ("country_vs_affiliation_type", "Country", "Affiliation type", False),
 ]
 
 
@@ -194,6 +92,172 @@ def elapsed_seconds(start_time: float) -> str:
     return f"{perf_counter() - start_time:.1f}s"
 
 
+def empty_report_frame() -> pd.DataFrame:
+    return pd.DataFrame(columns=["row_label", "column_label", "count"])
+
+
+def load_power_normalized_publication_weights(
+    conn,
+    query: str,
+    label_column: str,
+    weight_column: str,
+) -> pd.DataFrame:
+    """Load raw DB similarities and derive report-time publication weights."""
+    raw = pd.read_sql_query(text(query), conn)
+    if raw.empty:
+        return pd.DataFrame(
+            columns=["publication_id", label_column, weight_column]
+        )
+
+    rows = []
+    for publication_id, group in raw.groupby("publication_id", sort=False):
+        weights = power_normalize(
+            group["semantic_similarity"].to_numpy(dtype=np.float64)
+        )
+        for label, weight in zip(group["label"], weights):
+            if weight > 0.0:
+                rows.append(
+                    {
+                        "publication_id": publication_id,
+                        label_column: label,
+                        weight_column: float(weight),
+                    }
+                )
+
+    return pd.DataFrame(
+        rows, columns=["publication_id", label_column, weight_column]
+    )
+
+
+def load_report_inputs(conn):
+    logger.info("Loading raw subject similarities")
+    subject_weights = load_power_normalized_publication_weights(
+        conn,
+        RAW_SUBJECT_QUERY,
+        "subject",
+        "subject_weight",
+    )
+    logger.info("Loaded transformed subject weights: rows=%s", len(subject_weights))
+
+    logger.info("Loading raw affiliation similarities")
+    affiliation_weights = load_power_normalized_publication_weights(
+        conn,
+        RAW_AFFILIATION_QUERY,
+        "affiliation_type",
+        "affiliation_weight",
+    )
+    logger.info(
+        "Loaded transformed affiliation weights: rows=%s",
+        len(affiliation_weights),
+    )
+
+    logger.info("Loading country map")
+    country_map = pd.read_sql_query(text(COUNTRY_MAP_QUERY), conn)
+    logger.info("Loaded country map: rows=%s", len(country_map))
+
+    return subject_weights, affiliation_weights, country_map
+
+
+def build_affiliation_type_vs_subject(
+    subject_weights: pd.DataFrame,
+    affiliation_weights: pd.DataFrame,
+) -> pd.DataFrame:
+    if subject_weights.empty or affiliation_weights.empty:
+        return empty_report_frame()
+
+    affiliation_subject = affiliation_weights.merge(
+        subject_weights, on="publication_id", how="inner"
+    )
+    affiliation_subject["count"] = (
+        affiliation_subject["affiliation_weight"]
+        * affiliation_subject["subject_weight"]
+    )
+    return (
+        affiliation_subject.groupby(["affiliation_type", "subject"], as_index=False)[
+            "count"
+        ]
+        .sum()
+        .rename(
+            columns={
+                "affiliation_type": "row_label",
+                "subject": "column_label",
+            }
+        )
+    )
+
+
+def build_country_vs_subject(
+    country_map: pd.DataFrame,
+    subject_weights: pd.DataFrame,
+) -> pd.DataFrame:
+    if country_map.empty or subject_weights.empty:
+        return empty_report_frame()
+
+    country_subject = country_map.merge(
+        subject_weights, on="publication_id", how="inner"
+    )
+    return (
+        country_subject.groupby(["country", "subject"], as_index=False)[
+            "subject_weight"
+        ]
+        .sum()
+        .rename(
+            columns={
+                "country": "row_label",
+                "subject": "column_label",
+                "subject_weight": "count",
+            }
+        )
+    )
+
+
+def build_country_vs_affiliation_type(
+    country_map: pd.DataFrame,
+    affiliation_weights: pd.DataFrame,
+) -> pd.DataFrame:
+    if country_map.empty or affiliation_weights.empty:
+        return empty_report_frame()
+
+    country_affiliation = country_map.merge(
+        affiliation_weights, on="publication_id", how="inner"
+    )
+    return (
+        country_affiliation.groupby(["country", "affiliation_type"], as_index=False)[
+            "affiliation_weight"
+        ]
+        .sum()
+        .rename(
+            columns={
+                "country": "row_label",
+                "affiliation_type": "column_label",
+                "affiliation_weight": "count",
+            }
+        )
+    )
+
+
+def build_report_frames(conn) -> dict[str, pd.DataFrame]:
+    # The database stores raw semantic similarities. These data frames hold
+    # report-time weights derived with the shared fourth-power normalizer.
+    subject_weights, affiliation_weights, country_map = load_report_inputs(conn)
+
+    return {
+        "affiliation_type_vs_subject": build_affiliation_type_vs_subject(
+            subject_weights,
+            affiliation_weights,
+        ),
+        "country_vs_year": pd.read_sql_query(text(COUNTRY_VS_YEAR_QUERY), conn),
+        "country_vs_subject": build_country_vs_subject(
+            country_map,
+            subject_weights,
+        ),
+        "country_vs_affiliation_type": build_country_vs_affiliation_type(
+            country_map,
+            affiliation_weights,
+        ),
+    }
+
+
 engine = create_engine(f"sqlite:///{db_path}")
 
 logger.info("Starting affiliation country/subject/year analysis")
@@ -206,14 +270,15 @@ if tqdm is not None:
     report_iterator = tqdm(reports, desc="reports", unit="report")
 
 with engine.connect() as conn:
-    for stem, row_name, col_name, title, integer_values, query in report_iterator:
+    report_frames = build_report_frames(conn)
+
+    for stem, row_name, col_name, integer_values in report_iterator:
         report_start = perf_counter()
         logger.info("Starting report: %s", stem)
-        logger.info("Running SQL query for %s", stem)
         query_start = perf_counter()
-        df = pd.read_sql_query(text(query), conn)
+        df = report_frames[stem]
         logger.info(
-            "SQL complete for %s: rows=%s elapsed=%s",
+            "Data ready for %s: rows=%s elapsed=%s",
             stem,
             len(df),
             elapsed_seconds(query_start),

--- a/analyze_affiliation_country_subject_year.py
+++ b/analyze_affiliation_country_subject_year.py
@@ -24,39 +24,7 @@ logger = logging.getLogger(__name__)
 out_dir.mkdir(exist_ok=True)
 
 common_ctes = """
-with top_subject as (
-    select publication_id, short_name as subject
-    from (
-        select
-            btpd.publication_id,
-            bt.short_name,
-            row_number() over (
-                partition by btpd.publication_id
-                order by btpd.semantic_similarity desc, bt.id
-            ) as rn
-        from base_topic_to_pub_distance btpd
-        join base_topics bt on bt.id = btpd.base_topic_id
-        where btpd.semantic_similarity > 0
-    )
-    where rn = 1
-),
-top_affiliation as (
-    select publication_id, short_name as affiliation_type
-    from (
-        select
-            atpd.publication_id,
-            aft.short_name,
-            row_number() over (
-                partition by atpd.publication_id
-                order by atpd.semantic_similarity desc, aft.id
-            ) as rn
-        from affiliation_type_to_pub_distance atpd
-        join affiliation_types aft on aft.id = atpd.affiliation_type_id
-        where atpd.semantic_similarity > 0
-    )
-    where rn = 1
-),
-country_map as (
+with country_map as (
     select distinct
         ppal.publication_id,
         l.name as country
@@ -67,23 +35,55 @@ country_map as (
 """
 
 soft_weight_ctes = """
-with positive_subject as (
+with subject_power as (
     select
         btpd.publication_id,
         bt.short_name as subject,
-        btpd.semantic_similarity as subject_weight
+        case
+            when btpd.semantic_similarity > 0
+            then btpd.semantic_similarity
+                * btpd.semantic_similarity
+                * btpd.semantic_similarity
+                * btpd.semantic_similarity
+            else 0
+        end as subject_power
     from base_topic_to_pub_distance btpd
     join base_topics bt on bt.id = btpd.base_topic_id
-    where btpd.semantic_similarity > 0
 ),
-positive_affiliation as (
+positive_subject as (
+    select
+        publication_id,
+        subject,
+        subject_power
+            / sum(subject_power) over (partition by publication_id)
+            as subject_weight
+    from subject_power
+    where subject_power > 0
+),
+affiliation_power as (
     select
         atpd.publication_id,
         aft.short_name as affiliation_type,
-        atpd.semantic_similarity as affiliation_weight
+        case
+            when atpd.semantic_similarity > 0
+            then atpd.semantic_similarity
+                * atpd.semantic_similarity
+                * atpd.semantic_similarity
+                * atpd.semantic_similarity
+            else 0
+        end as affiliation_power
     from affiliation_type_to_pub_distance atpd
     join affiliation_types aft on aft.id = atpd.affiliation_type_id
-    where atpd.semantic_similarity > 0
+),
+positive_affiliation as (
+    select
+        publication_id,
+        affiliation_type,
+        affiliation_power
+            / sum(affiliation_power) over (partition by publication_id)
+            as affiliation_weight
+    from affiliation_power
+    where affiliation_power > 0
 )
 """
 

--- a/analyze_affiliation_country_subject_year.py
+++ b/analyze_affiliation_country_subject_year.py
@@ -23,6 +23,9 @@ logger = logging.getLogger(__name__)
 
 out_dir.mkdir(exist_ok=True)
 
+# The database stores raw semantic similarities. These CTEs derive report-time
+# weights by clipping negatives, raising positives to the fourth power, and
+# normalizing each publication vector so it sums to 1.0 before aggregation.
 common_ctes = """
 with country_map as (
     select distinct

--- a/analyze_affiliation_type_copublishing.py
+++ b/analyze_affiliation_type_copublishing.py
@@ -142,6 +142,7 @@ def build_copublishing_matrix(
         nonlocal current_vector, author_count
         if current_vector is None:
             return
+        # Stored similarities stay raw; co-publishing uses report-time weights.
         author_vectors.append(power_normalize(current_vector))
         author_count += 1
         current_vector = None

--- a/analyze_affiliation_type_copublishing.py
+++ b/analyze_affiliation_type_copublishing.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 Build an affiliation-type co-publishing matrix across authors on the same paper.
 
 For each publication, the script loads positive affiliation-type weights for
-each author. It then adds pairwise products between every author and every other
-author on that publication into a directed matrix: source affiliation type ->
-target affiliation type.
+each author, fourth-power normalizes each author affiliation vector, and then
+adds pairwise products between every author and every other author on that
+publication into a directed matrix: source affiliation type -> target
+affiliation type.
 
 Same-type to same-type products are included when they come from different
 authors. Self-products from the same author are excluded.
@@ -28,6 +29,7 @@ try:
 except ImportError:
     tqdm = None
 
+from affiliation_vector_transform import power_normalize
 from models import (
     AffiliationType,
     PublicationAuthorLocation,
@@ -140,7 +142,7 @@ def build_copublishing_matrix(
         nonlocal current_vector, author_count
         if current_vector is None:
             return
-        author_vectors.append(current_vector)
+        author_vectors.append(power_normalize(current_vector))
         author_count += 1
         current_vector = None
 

--- a/analyze_author_country_affiliation_type_weights.py
+++ b/analyze_author_country_affiliation_type_weights.py
@@ -125,6 +125,7 @@ def write_matrix_csv(
         nonlocal current_vector
         if current_vector is None or current_country is None:
             return
+        # Stored similarities stay raw; country totals use report-time weights.
         country_vector = countries.setdefault(
             current_country,
             [0.0 for _ in affiliation_type_names],

--- a/analyze_author_country_affiliation_type_weights.py
+++ b/analyze_author_country_affiliation_type_weights.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 Build a country-by-affiliation-type weight matrix for all author locations.
 
 This analysis uses all author location rows in `publication_author_locations`,
-not just primary-author locations. It sums positive semantic similarity weights
-from `publication_author_location_to_affiliation_type_distance` by country and
-affiliation type, then writes a CSV matrix to `topic_mapping_reports`.
+not just primary-author locations. It fourth-power normalizes each
+author-location affiliation-type vector from
+`publication_author_location_to_affiliation_type_distance`, then sums those
+transformed weights by country and affiliation type.
 """
 
 import argparse
@@ -16,6 +17,7 @@ import logging
 from pathlib import Path
 from time import perf_counter
 
+import numpy as np
 from sqlalchemy import create_engine, event, func, select
 from sqlalchemy.orm import Session
 
@@ -24,6 +26,7 @@ try:
 except ImportError:
     tqdm = None
 
+from affiliation_vector_transform import power_normalize
 from models import (
     AffiliationType,
     Location,
@@ -72,15 +75,14 @@ def load_affiliation_types(session: Session):
     return affiliation_type_ids, affiliation_type_names, affiliation_type_index_by_id
 
 
-def load_country_affiliation_weights(session: Session):
+def iter_country_affiliation_weights(session: Session):
     country_name = func.trim(Location.name).label("country")
     query = (
         select(
             country_name,
+            PublicationAuthorLocation.id,
             PublicationAuthorLocationAffiliationTypeDistance.affiliation_type_id,
-            func.sum(
-                PublicationAuthorLocationAffiliationTypeDistance.semantic_similarity
-            ),
+            PublicationAuthorLocationAffiliationTypeDistance.semantic_similarity,
         )
         .join(
             PublicationAuthorLocation,
@@ -92,11 +94,8 @@ def load_country_affiliation_weights(session: Session):
         .where(
             PublicationAuthorLocationAffiliationTypeDistance.semantic_similarity > 0.0
         )
-        .group_by(
-            country_name,
-            PublicationAuthorLocationAffiliationTypeDistance.affiliation_type_id,
-        )
         .order_by(
+            PublicationAuthorLocation.id,
             country_name,
             PublicationAuthorLocationAffiliationTypeDistance.affiliation_type_id,
         )
@@ -114,16 +113,39 @@ def write_matrix_csv(
     countries: dict[str, list[float]] = {}
     row_iterator = country_weight_rows
     if tqdm is not None:
-        row_iterator = tqdm(country_weight_rows, desc="Loading country weights", unit="row")
+        row_iterator = tqdm(
+            country_weight_rows, desc="Loading country weights", unit="row"
+        )
 
-    for country, affiliation_type_id, weight_sum in row_iterator:
+    current_author_location_id = None
+    current_country = None
+    current_vector = None
+
+    def flush_author_location() -> None:
+        nonlocal current_vector
+        if current_vector is None or current_country is None:
+            return
         country_vector = countries.setdefault(
-            country,
+            current_country,
             [0.0 for _ in affiliation_type_names],
         )
-        country_vector[affiliation_type_index_by_id[affiliation_type_id]] = float(
-            weight_sum or 0.0
+        for index, weight in enumerate(power_normalize(current_vector)):
+            if weight > 0.0:
+                country_vector[index] += float(weight)
+        current_vector = None
+
+    for country, author_location_id, affiliation_type_id, semantic_similarity in row_iterator:
+        if author_location_id != current_author_location_id:
+            flush_author_location()
+            current_author_location_id = author_location_id
+            current_country = country
+            current_vector = np.zeros(len(affiliation_type_names), dtype=np.float64)
+
+        current_vector[affiliation_type_index_by_id[affiliation_type_id]] = float(
+            semantic_similarity
         )
+
+    flush_author_location()
 
     logger.info("Writing %d country rows to %s", len(countries), path)
     with open(path, "w", newline="", encoding="utf-8") as file:
@@ -168,8 +190,8 @@ def main() -> None:
         )
 
         query_start = perf_counter()
-        logger.info("Running grouped country-by-affiliation-type weight query")
-        country_weight_rows = load_country_affiliation_weights(session)
+        logger.info("Running country-by-affiliation-type weight query")
+        country_weight_rows = iter_country_affiliation_weights(session)
         write_matrix_csv(
             output_path,
             affiliation_type_names,

--- a/analyze_sensors_to_topics.py
+++ b/analyze_sensors_to_topics.py
@@ -3,10 +3,12 @@ import csv
 import logging
 from pathlib import Path
 
+import numpy as np
 from tqdm import tqdm
 from sqlalchemy import create_engine, event, select
 from sqlalchemy.orm import Session
 
+from affiliation_vector_transform import power_normalize
 from models import (
     Base,
     Publication,
@@ -49,6 +51,9 @@ with Session(engine) as session:
     topics_id_name = session.execute(
         select(BaseTopics.id, BaseTopics.short_name)
     ).all()
+    topic_id_to_index = {
+        topic_id: index for index, (topic_id, _) in enumerate(topics_id_name)
+    }
 
     logging.info("Loading publications")
     publications_id_abstract = session.execute(
@@ -86,24 +91,32 @@ with Session(engine) as session:
         topic_name: {sensor: 0.0 for sensor in sensor_names}
         for _, topic_name in topics_id_name
     }
-    topic_id_to_name = {
-        topic_id: topic_name for topic_id, topic_name in topics_id_name
-    }
+    topic_names = [topic_name for _, topic_name in topics_id_name]
 
-    logging.info("Accumulating topic-to-sensor closeness")
+    logging.info("Building publication-level topic vectors")
+    publication_to_topic_scores = {}
     for topic_id, pub_id, semantic_similarity in tqdm(
-        topic_pub_distances, desc="Accumulating"
+        topic_pub_distances, desc="Topic vectors"
     ):
-        if semantic_similarity < 0:
-            continue
+        scores = publication_to_topic_scores.setdefault(
+            pub_id, np.zeros(len(topics_id_name), dtype=np.float64)
+        )
+        scores[topic_id_to_index[topic_id]] = float(semantic_similarity)
+
+    logging.info("Accumulating transformed topic-to-sensor closeness")
+    for pub_id, topic_scores in tqdm(
+        publication_to_topic_scores.items(), desc="Accumulating"
+    ):
         sensor_idxs = publication_to_sensor_idxs[pub_id]
         if not sensor_idxs:
             continue
-        topic_name = topic_id_to_name[topic_id]
-        if topic_name is None:
-            continue
+        topic_weights = power_normalize(topic_scores)
         for sensor_idx in sensor_idxs:
-            matrix[topic_name][sensor_names[sensor_idx]] += semantic_similarity
+            sensor_name = sensor_names[sensor_idx]
+            for topic_name, topic_weight in zip(topic_names, topic_weights):
+                if topic_name is None or topic_weight <= 0.0:
+                    continue
+                matrix[topic_name][sensor_name] += float(topic_weight)
 
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
     reports_dir.mkdir(exist_ok=True)

--- a/analyze_sensors_to_topics.py
+++ b/analyze_sensors_to_topics.py
@@ -93,6 +93,8 @@ with Session(engine) as session:
     }
     topic_names = [topic_name for _, topic_name in topics_id_name]
 
+    # The database stores raw semantic similarities. Transform those raw
+    # publication-level topic vectors only at report time.
     logging.info("Building publication-level topic vectors")
     publication_to_topic_scores = {}
     for topic_id, pub_id, semantic_similarity in tqdm(

--- a/calculate_weighted_base_topic_publication_similarities.py
+++ b/calculate_weighted_base_topic_publication_similarities.py
@@ -42,6 +42,8 @@ SessionLocal = sessionmaker(bind=engine)
 
 
 def load_transformed_topic_weights(session, topic_ids: list[int]):
+    # The database stores raw semantic similarities. Ranking uses report-time
+    # transformed topic weights so raw scores remain available for other uses.
     topic_index_by_id = {topic_id: index for index, topic_id in enumerate(topic_ids)}
     rows = session.execute(
         select(

--- a/calculate_weighted_base_topic_publication_similarities.py
+++ b/calculate_weighted_base_topic_publication_similarities.py
@@ -4,11 +4,12 @@ similarity score.
 
 The weighted score for a (base_topic, publication) pair is computed as:
 
-  clamp01(sim(base_topic, publication)) * clamp01(sim(weight_topic, publication))
+  transformed_weight(base_topic, publication)
+  * transformed_weight(weight_topic, publication)
 
 Where:
-- sim(...) is the stored semantic similarity in BaseTopicToPublicationDistance
-- clamp01(...) clamps similarities into the [0.0, 1.0] range
+- transformed_weight(...) comes from fourth-power normalizing the full
+  publication-level topic vector from BaseTopicToPublicationDistance
 
 The output CSV contains one row per selected publication per base topic with:
 - base topic (short name)
@@ -27,32 +28,51 @@ Example:
 """
 
 import csv
-from sqlalchemy import create_engine, select, desc, case, literal
-from sqlalchemy.orm import sessionmaker, aliased
+from collections import defaultdict
 
+import numpy as np
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from affiliation_vector_transform import power_normalize
 from models import BaseTopics, BaseTopicToPublicationDistance, Publication
 
 engine = create_engine("sqlite:///2025_11_09_researchgate.sqlite")
 SessionLocal = sessionmaker(bind=engine)
 
 
-def clamp01(expr):
-    """Clamp a SQLAlchemy numeric expression to the inclusive [0.0, 1.0] range.
+def load_transformed_topic_weights(session, topic_ids: list[int]):
+    topic_index_by_id = {topic_id: index for index, topic_id in enumerate(topic_ids)}
+    rows = session.execute(
+        select(
+            BaseTopicToPublicationDistance.publication_id,
+            BaseTopicToPublicationDistance.base_topic_id,
+            BaseTopicToPublicationDistance.semantic_similarity,
+        ).order_by(
+            BaseTopicToPublicationDistance.publication_id,
+            BaseTopicToPublicationDistance.base_topic_id,
+        )
+    ).all()
 
-    Args:
-        expr: A SQLAlchemy expression that evaluates to a numeric value.
+    weights_by_publication = {}
+    current_publication_id = None
+    current_scores = None
 
-    Returns:
-        A SQLAlchemy CASE expression that yields:
-        - 0.0 when expr < 0.0
-        - 1.0 when expr > 1.0
-        - expr otherwise
-    """
-    return case(
-        (expr < 0.0, 0.0),
-        (expr > 1.0, 1.0),
-        else_=expr,
-    )
+    def flush_publication() -> None:
+        if current_publication_id is not None and current_scores is not None:
+            weights_by_publication[current_publication_id] = power_normalize(
+                current_scores
+            )
+
+    for publication_id, topic_id, semantic_similarity in rows:
+        if publication_id != current_publication_id:
+            flush_publication()
+            current_publication_id = publication_id
+            current_scores = np.zeros(len(topic_ids), dtype=np.float64)
+        current_scores[topic_index_by_id[topic_id]] = float(semantic_similarity)
+
+    flush_publication()
+    return weights_by_publication, topic_index_by_id
 
 
 def export_top_n_per_base_topic_csv(
@@ -62,7 +82,8 @@ def export_top_n_per_base_topic_csv(
 
     For each base topic, selects up to N publications and ranks them by:
 
-      clamp01(sim(base_topic, publication)) * clamp01(sim(weight_topic, publication))
+      transformed_weight(base_topic, publication)
+      * transformed_weight(weight_topic, publication)
 
     The weight topic is identified by matching BaseTopics.text to weight_topic_text.
 
@@ -84,12 +105,29 @@ def export_top_n_per_base_topic_csv(
         select(BaseTopics.id).where(BaseTopics.text == weight_topic_text)
     ).scalar_one()
 
-    D = BaseTopicToPublicationDistance
-    W = aliased(BaseTopicToPublicationDistance)
-
     base_topics = session.execute(
-        select(BaseTopics.id, BaseTopics.text).order_by(BaseTopics.text.asc())
+        select(BaseTopics.id, BaseTopics.text, BaseTopics.short_name).order_by(
+            BaseTopics.text.asc()
+        )
     ).all()
+    topic_ids = [topic_id for topic_id, _, _ in base_topics]
+    weights_by_publication, topic_index_by_id = load_transformed_topic_weights(
+        session, topic_ids
+    )
+    weight_topic_index = topic_index_by_id[weight_topic_id]
+
+    scores_by_topic = defaultdict(list)
+    for publication_id, topic_weights in weights_by_publication.items():
+        weight_topic_score = topic_weights[weight_topic_index]
+        if weight_topic_score <= 0.0:
+            continue
+        for topic_id in topic_ids:
+            topic_score = topic_weights[topic_index_by_id[topic_id]]
+            weighted_score = topic_score * weight_topic_score
+            if weighted_score > 0.0:
+                scores_by_topic[topic_id].append(
+                    (float(weighted_score), publication_id)
+                )
 
     with open(output_path, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
@@ -97,39 +135,31 @@ def export_top_n_per_base_topic_csv(
             ["base topic", "weighted semantic similarity", "title", "abstract"]
         )
 
-        for bt_id, bt_text in base_topics:
-            weighted_score = clamp01(D.semantic_similarity) * clamp01(
-                W.semantic_similarity
+        selected_publication_ids = {
+            publication_id
+            for topic_scores in scores_by_topic.values()
+            for _, publication_id in sorted(
+                topic_scores, key=lambda item: (-item[0], item[1])
+            )[:n]
+        }
+        publication_by_id = {
+            publication_id: (title, abstract)
+            for publication_id, title, abstract in session.execute(
+                select(Publication.id, Publication.title, Publication.abstract).where(
+                    Publication.id.in_(selected_publication_ids)
+                )
             )
+        }
 
-            rows = session.execute(
-                select(
-                    BaseTopics.text,
-                    BaseTopics.short_name,
-                    weighted_score.label("weighted_score"),
-                    Publication.title,
-                    Publication.abstract,
+        for bt_id, _, base_topic_short_name in base_topics:
+            top_rows = sorted(
+                scores_by_topic[bt_id], key=lambda item: (-item[0], item[1])
+            )[:n]
+            for weighted_score, publication_id in top_rows:
+                title, abstract = publication_by_id[publication_id]
+                writer.writerow(
+                    [base_topic_short_name, weighted_score, title, abstract]
                 )
-                .join(D, D.base_topic_id == BaseTopics.id)
-                .join(Publication, Publication.id == D.publication_id)
-                .join(
-                    W,
-                    (W.publication_id == D.publication_id)
-                    & (W.base_topic_id == literal(weight_topic_id)),
-                )
-                .where(BaseTopics.id == bt_id)
-                .order_by(desc(weighted_score), Publication.id.asc())
-                .limit(n)
-            ).all()
-
-            for (
-                base_topic,
-                base_topic_short_name,
-                wsim,
-                title,
-                abstract,
-            ) in rows:
-                writer.writerow([base_topic_short_name, float(wsim), title, abstract])
 
 
 with SessionLocal() as session:


### PR DESCRIPTION
## Proposed solution
Refactor downstream reports that were still aggregating raw subject or affiliation semantic similarities so they now use fourth-power normalization at report time.

The database similarity tables remain raw and should not be dropped/recreated for this change. This PR only changes report-time interpretation: scripts read raw `semantic_similarity` values, derive fourth-power normalized vectors per publication or author-location with the shared `power_normalize()` helper, then aggregate those transformed weights into CSV outputs.

## Scope
- Power-normalize publication-level subject vectors before accumulating sensor-to-topic closeness.
- Load raw subject and affiliation rows in `analyze_affiliation_country_subject_year.py`, derive report-time weights with `power_normalize()`, then build the country/subject/affiliation reports from those normalized weights.
- Power-normalize author affiliation vectors before co-publishing pair products.
- Power-normalize author-location affiliation vectors before country-by-affiliation totals.
- Update the tracked weighted-topic publication exporter to rank with transformed topic weights.

## Non-goals
- Do not overwrite `semantic_similarity` values in the database.
- Do not drop or regenerate similarity tables.
- Do not change embedding/population scripts.

## Validation
- `python -m py_compile analyze_sensors_to_topics.py analyze_affiliation_country_subject_year.py analyze_affiliation_type_copublishing.py analyze_author_country_affiliation_type_weights.py calculate_weighted_base_topic_publication_similarities.py`
- `git diff --check`
- Grep check confirms no remaining hand-written SQL fourth-power multiplication of `semantic_similarity` values

Closes #64